### PR TITLE
#1 Enhanced BufferedOpenDrain, customizable toggle timing on `Alt~`

### DIFF
--- a/src/application/io_card.rs
+++ b/src/application/io_card.rs
@@ -79,7 +79,7 @@ impl PaymentReceive {
                 player: None,
                 price: None,
                 signal_count: Some(c),
-                pulse_duration: Some(_d),
+                pulse_duration: Some(d),
             }) => {
                 match self.origin {
                     Player::Player1 => host_1p,
@@ -87,7 +87,7 @@ impl PaymentReceive {
                     _ => host_1p,
                 }
                 .out_vend
-                .tick_tock(c.min(u8::MAX.into()) as u8)
+                .alt_tick_tock(c.min(u8::MAX.into()) as u8, d, d)
                 .await;
             }
             GenericPaymentRecv::Income(GenericIncomeInfo {

--- a/src/boards/mod.rs
+++ b/src/boards/mod.rs
@@ -19,7 +19,7 @@ use crate::components::serial_device::{self, card_reader_device_spawn, CardReade
 use crate::components::vend_side_bill::VendSideBill;
 use crate::semi_layer::buffered_opendrain::{buffered_opendrain_spawn, BufferedOpenDrain};
 use crate::semi_layer::buffered_wait_receiver::BufferedWaitReceiver;
-use crate::semi_layer::timing::{DualPoleToggleTiming, SharedToggleTiming, ToggleTiming};
+use crate::semi_layer::timing::{SharedToggleTiming, ToggleTiming};
 use crate::types::input_port::InputPortKind;
 
 pub const PLAYER_INDEX_MAX: usize = 2;
@@ -135,10 +135,10 @@ pub struct SharedResource {
     pub async_input_event_ch: BufferedWaitReceiver,
 
     /// Open-drain signal timing that shared or const-ish
-    pub arcade_players_timing: [DualPoleToggleTiming; PLAYER_INDEX_MAX],
+    pub arcade_players_timing: [SharedToggleTiming; PLAYER_INDEX_MAX],
 
     /// LED and start button LED related timing that shared or const-ish.
-    pub indicator_timing: DualPoleToggleTiming,
+    pub indicator_timing: SharedToggleTiming,
 }
 
 impl SharedResource {
@@ -150,20 +150,11 @@ impl SharedResource {
     fn init() -> Self {
         Self {
             async_input_event_ch: BufferedWaitReceiver::new(),
-            arcade_players_timing: [
-                DualPoleToggleTiming::new(SharedToggleTiming::default(), ToggleTiming::default()),
-                DualPoleToggleTiming::new(SharedToggleTiming::default(), ToggleTiming::default()),
-            ],
-            indicator_timing: DualPoleToggleTiming::new(
-                SharedToggleTiming::new_custom(ToggleTiming {
-                    high_ms: 500,
-                    low_ms: 500,
-                }),
-                ToggleTiming {
-                    high_ms: 1000,
-                    low_ms: 1000,
-                },
-            ),
+            arcade_players_timing: [SharedToggleTiming::default(), SharedToggleTiming::default()],
+            indicator_timing: SharedToggleTiming::new_custom(ToggleTiming {
+                high_ms: 500,
+                low_ms: 500,
+            }),
         }
     }
 }

--- a/src/components/host_side_bill.rs
+++ b/src/components/host_side_bill.rs
@@ -11,7 +11,7 @@ use embassy_stm32::gpio::{AnyPin, Output};
 
 use crate::semi_layer::buffered_opendrain::{buffered_opendrain_spawn, BufferedOpenDrain};
 use crate::semi_layer::buffered_wait::{buffered_wait_spawn, BufferedWait, InputEventChannel};
-use crate::semi_layer::timing::DualPoleToggleTiming;
+use crate::semi_layer::timing::SharedToggleTiming;
 use crate::types::const_convert::ConstInto;
 use crate::types::input_port::InputPortKind;
 
@@ -32,14 +32,14 @@ impl HostSideBill {
         out_jam: Output<'static, AnyPin>,
         out_start: Output<'static, AnyPin>,
         mpsc_ch: &'static InputEventChannel,
-        timing: &'static DualPoleToggleTiming,
+        shared_timing: &'static SharedToggleTiming,
     ) -> Self {
         Self {
             in_inhibit: BufferedWait::new(in_inhibit, in_inhibit_event.const_into(), mpsc_ch),
-            out_busy: BufferedOpenDrain::new(out_busy, timing),
-            out_vend: BufferedOpenDrain::new(out_vend, timing),
-            out_jam: BufferedOpenDrain::new(out_jam, timing),
-            out_start: BufferedOpenDrain::new(out_start, timing),
+            out_busy: BufferedOpenDrain::new(out_busy, shared_timing),
+            out_vend: BufferedOpenDrain::new(out_vend, shared_timing),
+            out_jam: BufferedOpenDrain::new(out_jam, shared_timing),
+            out_start: BufferedOpenDrain::new(out_start, shared_timing),
         }
     }
 

--- a/src/components/start_button.rs
+++ b/src/components/start_button.rs
@@ -11,7 +11,7 @@ use embassy_stm32::gpio::{AnyPin, Output};
 
 use crate::semi_layer::buffered_opendrain::{buffered_opendrain_spawn, BufferedOpenDrain};
 use crate::semi_layer::buffered_wait::{buffered_wait_spawn, BufferedWait, InputEventChannel};
-use crate::semi_layer::timing::DualPoleToggleTiming;
+use crate::semi_layer::timing::SharedToggleTiming;
 use crate::types::const_convert::ConstInto;
 use crate::types::input_port::InputPortKind;
 
@@ -29,11 +29,11 @@ impl StartButton {
         in_switch_event: InputPortKind,
         out_led: Output<'static, AnyPin>,
         mpsc_ch: &'static InputEventChannel,
-        timing: &'static DualPoleToggleTiming,
+        shared_timing: &'static SharedToggleTiming,
     ) -> Self {
         Self {
             in_switch: BufferedWait::new(in_switch, in_switch_event.const_into(), mpsc_ch),
-            out_led: BufferedOpenDrain::new(out_led, timing),
+            out_led: BufferedOpenDrain::new(out_led, shared_timing),
         }
     }
 

--- a/src/components/vend_side_bill.rs
+++ b/src/components/vend_side_bill.rs
@@ -11,7 +11,7 @@ use embassy_stm32::gpio::{AnyPin, Output};
 
 use crate::semi_layer::buffered_opendrain::{buffered_opendrain_spawn, BufferedOpenDrain};
 use crate::semi_layer::buffered_wait::{buffered_wait_spawn, BufferedWait, InputEventChannel};
-use crate::semi_layer::timing::DualPoleToggleTiming;
+use crate::semi_layer::timing::SharedToggleTiming;
 use crate::types::const_convert::ConstInto;
 use crate::types::input_port::InputPortKind;
 
@@ -29,10 +29,10 @@ impl VendSideBill {
         in_start_jam: ExtiInput<'static, AnyPin>,
         in_start_jam_event: InputPortKind,
         mpsc_ch: &'static InputEventChannel,
-        timing: &'static DualPoleToggleTiming,
+        shared_timing: &'static SharedToggleTiming,
     ) -> VendSideBill {
         Self {
-            out_inhibit: BufferedOpenDrain::new(out_inhibit, timing),
+            out_inhibit: BufferedOpenDrain::new(out_inhibit, shared_timing),
             in_vend: BufferedWait::new(in_vend, in_vend_event.const_into(), mpsc_ch),
             in_start_jam: BufferedWait::new(in_start_jam, in_start_jam_event.const_into(), mpsc_ch),
         }

--- a/src/semi_layer/buffered_opendrain.rs
+++ b/src/semi_layer/buffered_opendrain.rs
@@ -519,10 +519,10 @@ impl BufferedOpenDrain {
     }
 }
 
-// in HW v0.2 pool usage would be 13.
-// PCB has 13 N-MOS open-drain.
-// single task pool consume 112 bytes
-#[embassy_executor::task(pool_size = 13)]
+// in HW v0.2 pool usage would be 13, but latest BSP only allow 12 output.
+// in HW v0.3 pool usage would be 12. PCB has 12 N-MOS open-drain.
+// single task pool consume 120 bytes
+#[embassy_executor::task(pool_size = 12)]
 pub async fn buffered_opendrain_spawn(instance: &'static BufferedOpenDrain) {
     instance.run().await
 }

--- a/src/semi_layer/buffered_opendrain.rs
+++ b/src/semi_layer/buffered_opendrain.rs
@@ -134,6 +134,9 @@ const BF_13_8_SET_HIGH: u16 = 0b00_0001;
 const BF_13_8_TICKTOCK: u16 = 0b00_0010;
 const BF_13_8_FOREVER_BLINK: u16 = 0b00_0011;
 
+const BF_U5_MAX: u16 = (1u16 << 5) - 1;
+const BF_U7_MAX: u16 = (1u16 << 7) - 1;
+
 pub struct RawBufferedOpenDrainRequestTryIntoError {
     pub inner: RawBufferedOpenDrainRequest,
 }
@@ -186,7 +189,7 @@ impl From<&BufferedOpenDrainRequest> for RawBufferedOpenDrainRequest {
         match value {
             BufferedOpenDrainRequest::SetLow => BF_13_8_SET_LOW << 8,
             BufferedOpenDrainRequest::SetHigh => BF_13_8_SET_HIGH << 8,
-            BufferedOpenDrainRequest::TickTock(x) => *x as u16 + (BF_13_8_TICKTOCK << 8),
+            BufferedOpenDrainRequest::TickTock(x) => *x as u16 | (BF_13_8_TICKTOCK << 8),
             BufferedOpenDrainRequest::AltTickTock(AltTickTockRequest {
                 toggle_count,
                 timing: ToggleTiming { high_ms, low_ms },
@@ -194,15 +197,15 @@ impl From<&BufferedOpenDrainRequest> for RawBufferedOpenDrainRequest {
                 let mut ret = 0u16;
                 *ret.set_bits(14..=15, BF_15_14_ALT_TICKTOCK)
                     .set_bits(10..=13, *toggle_count as u16)
-                    .set_bits(5..=9, (*high_ms / 10).min(1 << 5))
-                    .set_bits(0..=4, (*low_ms / 10).min(1 << 5))
+                    .set_bits(5..=9, (*high_ms / 10).min(BF_U5_MAX))
+                    .set_bits(0..=4, (*low_ms / 10).min(BF_U5_MAX))
             }
             BufferedOpenDrainRequest::ForeverBlink => BF_13_8_FOREVER_BLINK << 8,
             BufferedOpenDrainRequest::AltForeverBlink(ToggleTiming { high_ms, low_ms }) => {
                 let mut ret = 0u16;
                 *ret.set_bits(14..=15, BF_15_14_ALT_FOREVER_BLINK)
-                    .set_bits(7..=13, (*high_ms / 10).min(1 << 7))
-                    .set_bits(0..=6, (*low_ms / 10).min(1 << 7))
+                    .set_bits(7..=13, (*high_ms / 10).min(BF_U7_MAX))
+                    .set_bits(0..=6, (*low_ms / 10).min(BF_U7_MAX))
             }
         }
     }
@@ -213,7 +216,7 @@ impl From<BufferedOpenDrainRequest> for RawBufferedOpenDrainRequest {
         match value {
             BufferedOpenDrainRequest::SetLow => BF_13_8_SET_LOW << 8,
             BufferedOpenDrainRequest::SetHigh => BF_13_8_SET_HIGH << 8,
-            BufferedOpenDrainRequest::TickTock(x) => x as u16 + (BF_13_8_TICKTOCK << 8),
+            BufferedOpenDrainRequest::TickTock(x) => x as u16 | (BF_13_8_TICKTOCK << 8),
             BufferedOpenDrainRequest::AltTickTock(AltTickTockRequest {
                 toggle_count,
                 timing: ToggleTiming { high_ms, low_ms },
@@ -221,15 +224,15 @@ impl From<BufferedOpenDrainRequest> for RawBufferedOpenDrainRequest {
                 let mut ret = 0u16;
                 *ret.set_bits(14..=15, BF_15_14_ALT_TICKTOCK)
                     .set_bits(10..=13, toggle_count as u16)
-                    .set_bits(5..=9, (high_ms / 10).min(1 << 5))
-                    .set_bits(0..=4, (low_ms / 10).min(1 << 5))
+                    .set_bits(5..=9, (high_ms / 10).min(BF_U5_MAX))
+                    .set_bits(0..=4, (low_ms / 10).min(BF_U5_MAX))
             }
             BufferedOpenDrainRequest::ForeverBlink => BF_13_8_FOREVER_BLINK << 8,
             BufferedOpenDrainRequest::AltForeverBlink(ToggleTiming { high_ms, low_ms }) => {
                 let mut ret = 0u16;
                 *ret.set_bits(14..=15, BF_15_14_ALT_FOREVER_BLINK)
-                    .set_bits(7..=13, (high_ms / 10).min(1 << 7))
-                    .set_bits(0..=6, (low_ms / 10).min(1 << 7))
+                    .set_bits(7..=13, (high_ms / 10).min(BF_U7_MAX))
+                    .set_bits(0..=6, (low_ms / 10).min(BF_U7_MAX))
             }
         }
     }

--- a/src/semi_layer/buffered_opendrain.rs
+++ b/src/semi_layer/buffered_opendrain.rs
@@ -6,6 +6,7 @@
 
 use core::cell::UnsafeCell;
 
+use bit_field::BitField;
 use embassy_stm32::gpio::{AnyPin, Output};
 use embassy_sync::blocking_mutex::raw::ThreadModeRawMutex;
 use embassy_sync::channel::Channel;
@@ -15,7 +16,7 @@ use super::timing::{DualPoleToggleTiming, ToggleTiming};
 
 pub const HOST_SIDE_INTERFACE_CH_SIZE: usize = 2;
 pub type OpenDrainRequestChannel =
-    Channel<ThreadModeRawMutex, BufferedOpenDrainRequest, HOST_SIDE_INTERFACE_CH_SIZE>;
+    Channel<ThreadModeRawMutex, RawBufferedOpenDrainRequest, HOST_SIDE_INTERFACE_CH_SIZE>;
 
 struct NanoFsm {
     /// Given or left toggle number
@@ -97,6 +98,11 @@ impl BlinkFsm {
     }
 }
 
+pub struct AltTickTockRequest {
+    pub toggle_count: u8,
+    pub timing: ToggleTiming,
+}
+
 pub enum BufferedOpenDrainRequest {
     /// Set low
     SetLow,
@@ -104,14 +110,129 @@ pub enum BufferedOpenDrainRequest {
     SetHigh,
     /// Set high and low with shared configuration
     TickTock(u8),
-    /// Set high and low with alternative means secondary shared configuration.
-    /// secondary shared configuration is to saving compute resource and RAM usage.
-    AltTickTock(u8),
+    /// Set high and low with alternative light configuration.
+    /// Alternative light configuration is passing with limited paramter.
+    /// toggle_count : u4(1..15)
+    /// on/off_time  : u5(1..31) * 10 ms
+    AltTickTock(AltTickTockRequest),
     /// Forever blink until not cancel
     ForeverBlink,
-    /// Forever blink until not cancel with alternative configuartion
-    /// secondary shared configuration is to saving compute resource and RAM usage.
-    AltForeverBlink,
+    /// Forever blink until not cancel with alternative light configuration.
+    /// Alternative light configuration is passing with limited paramter.
+    /// on/off_time  : u7(1..127) * 10 ms
+    AltForeverBlink(ToggleTiming),
+}
+
+pub type RawBufferedOpenDrainRequest = u16;
+
+const BF_15_14_OTHERS: u16 = 0b00;
+const BF_15_14_ALT_TICKTOCK: u16 = 0b10;
+const BF_15_14_ALT_FOREVER_BLINK: u16 = 0b11;
+
+const BF_13_8_SET_LOW: u16 = 0b00_0000;
+const BF_13_8_SET_HIGH: u16 = 0b00_0001;
+const BF_13_8_TICKTOCK: u16 = 0b00_0010;
+const BF_13_8_FOREVER_BLINK: u16 = 0b00_0011;
+
+pub struct RawBufferedOpenDrainRequestTryIntoError {
+    pub inner: RawBufferedOpenDrainRequest,
+}
+
+impl TryFrom<RawBufferedOpenDrainRequest> for BufferedOpenDrainRequest {
+    type Error = RawBufferedOpenDrainRequestTryIntoError;
+
+    fn try_from(value: RawBufferedOpenDrainRequest) -> Result<Self, Self::Error> {
+        match value.get_bits(14..=15) {
+            BF_15_14_OTHERS => match (value.get_bits(8..=13), value.get_bits(0..=7) as u8) {
+                (BF_13_8_SET_LOW, 0) => Ok(Self::SetLow),
+                (BF_13_8_SET_HIGH, 0) => Ok(Self::SetHigh),
+                (BF_13_8_TICKTOCK, 0) => {
+                    Err(RawBufferedOpenDrainRequestTryIntoError { inner: value })
+                }
+                (BF_13_8_TICKTOCK, x) => Ok(Self::TickTock(x)),
+                (BF_13_8_FOREVER_BLINK, 0) => Ok(Self::ForeverBlink),
+                _ => Err(RawBufferedOpenDrainRequestTryIntoError { inner: value }),
+            },
+            BF_15_14_ALT_TICKTOCK => match (
+                value.get_bits(10..=13) as u8,
+                value.get_bits(5..=9),
+                value.get_bits(0..=4),
+            ) {
+                (0, _, _) | (_, 0, _) | (_, _, 0) => {
+                    Err(RawBufferedOpenDrainRequestTryIntoError { inner: value })
+                }
+                (x, y, z) => Ok(Self::AltTickTock(AltTickTockRequest {
+                    toggle_count: x,
+                    timing: ToggleTiming {
+                        high_ms: y * 10,
+                        low_ms: z * 10,
+                    },
+                })),
+            },
+            BF_15_14_ALT_FOREVER_BLINK => match (value.get_bits(7..=13), value.get_bits(0..=6)) {
+                (0, _) | (_, 0) => Err(RawBufferedOpenDrainRequestTryIntoError { inner: value }),
+                (x, y) => Ok(Self::AltForeverBlink(ToggleTiming {
+                    high_ms: x * 10,
+                    low_ms: y * 10,
+                })),
+            },
+            _ => Err(RawBufferedOpenDrainRequestTryIntoError { inner: value }),
+        }
+    }
+}
+
+impl From<&BufferedOpenDrainRequest> for RawBufferedOpenDrainRequest {
+    fn from(value: &BufferedOpenDrainRequest) -> Self {
+        match value {
+            BufferedOpenDrainRequest::SetLow => BF_13_8_SET_LOW << 8,
+            BufferedOpenDrainRequest::SetHigh => BF_13_8_SET_HIGH << 8,
+            BufferedOpenDrainRequest::TickTock(x) => *x as u16 + (BF_13_8_TICKTOCK << 8),
+            BufferedOpenDrainRequest::AltTickTock(AltTickTockRequest {
+                toggle_count,
+                timing: ToggleTiming { high_ms, low_ms },
+            }) => {
+                let mut ret = 0u16;
+                *ret.set_bits(14..=15, BF_15_14_ALT_TICKTOCK)
+                    .set_bits(10..=13, *toggle_count as u16)
+                    .set_bits(5..=9, (*high_ms / 10).min(1 << 5))
+                    .set_bits(0..=4, (*low_ms / 10).min(1 << 5))
+            }
+            BufferedOpenDrainRequest::ForeverBlink => BF_13_8_FOREVER_BLINK << 8,
+            BufferedOpenDrainRequest::AltForeverBlink(ToggleTiming { high_ms, low_ms }) => {
+                let mut ret = 0u16;
+                *ret.set_bits(14..=15, BF_15_14_ALT_FOREVER_BLINK)
+                    .set_bits(7..=13, (*high_ms / 10).min(1 << 7))
+                    .set_bits(0..=6, (*low_ms / 10).min(1 << 7))
+            }
+        }
+    }
+}
+
+impl From<BufferedOpenDrainRequest> for RawBufferedOpenDrainRequest {
+    fn from(value: BufferedOpenDrainRequest) -> Self {
+        match value {
+            BufferedOpenDrainRequest::SetLow => BF_13_8_SET_LOW << 8,
+            BufferedOpenDrainRequest::SetHigh => BF_13_8_SET_HIGH << 8,
+            BufferedOpenDrainRequest::TickTock(x) => x as u16 + (BF_13_8_TICKTOCK << 8),
+            BufferedOpenDrainRequest::AltTickTock(AltTickTockRequest {
+                toggle_count,
+                timing: ToggleTiming { high_ms, low_ms },
+            }) => {
+                let mut ret = 0u16;
+                *ret.set_bits(14..=15, BF_15_14_ALT_TICKTOCK)
+                    .set_bits(10..=13, toggle_count as u16)
+                    .set_bits(5..=9, (high_ms / 10).min(1 << 5))
+                    .set_bits(0..=4, (low_ms / 10).min(1 << 5))
+            }
+            BufferedOpenDrainRequest::ForeverBlink => BF_13_8_FOREVER_BLINK << 8,
+            BufferedOpenDrainRequest::AltForeverBlink(ToggleTiming { high_ms, low_ms }) => {
+                let mut ret = 0u16;
+                *ret.set_bits(14..=15, BF_15_14_ALT_FOREVER_BLINK)
+                    .set_bits(7..=13, (high_ms / 10).min(1 << 7))
+                    .set_bits(0..=6, (low_ms / 10).min(1 << 7))
+            }
+        }
+    }
 }
 
 enum MicroHsm {
@@ -123,12 +244,12 @@ enum MicroHsm {
     TickTock(NanoFsm),
     /// Set high and low with alternative means secondary shared configuration.
     /// secondary shared configuration is to saving compute resource and RAM usage.
-    AltTickTock(NanoFsm),
+    AltTickTock(NanoFsm, ToggleTiming),
     /// Forever blink until not cancel
     ForeverBlink(BlinkFsm),
     /// Forever blink until not cancel with alternative configuartion
     /// secondary shared configuration is to saving compute resource and RAM usage.
-    AltForeverBlink(BlinkFsm),
+    AltForeverBlink(BlinkFsm, ToggleTiming),
 }
 
 impl MicroHsm {
@@ -144,9 +265,12 @@ impl From<MicroHsm> for BufferedOpenDrainRequest {
             MicroHsm::SetLow => Self::SetLow,
             MicroHsm::SetHigh => Self::SetHigh,
             MicroHsm::TickTock(x) => Self::TickTock(x.toggle_count),
-            MicroHsm::AltTickTock(x) => Self::AltTickTock(x.toggle_count),
+            MicroHsm::AltTickTock(x, y) => Self::AltTickTock(AltTickTockRequest {
+                toggle_count: x.toggle_count,
+                timing: y,
+            }),
             MicroHsm::ForeverBlink(_) => Self::ForeverBlink,
-            MicroHsm::AltForeverBlink(_) => Self::AltForeverBlink,
+            MicroHsm::AltForeverBlink(_, y) => Self::AltForeverBlink(y),
         }
     }
 }
@@ -161,19 +285,25 @@ impl From<(BufferedOpenDrainRequest, &'static DualPoleToggleTiming)> for MicroHs
                 state: true,
                 duration: timing.shared.get().high_ms,
             }),
-            BufferedOpenDrainRequest::AltTickTock(x) => Self::AltTickTock(NanoFsm {
-                toggle_count: x,
-                state: true,
-                duration: timing.alt.high_ms,
-            }),
+            BufferedOpenDrainRequest::AltTickTock(x) => Self::AltTickTock(
+                NanoFsm {
+                    toggle_count: x.toggle_count,
+                    state: true,
+                    duration: timing.alt.high_ms,
+                },
+                x.timing,
+            ),
             BufferedOpenDrainRequest::ForeverBlink => Self::ForeverBlink(BlinkFsm {
                 state: true,
                 duration: timing.shared.get().high_ms,
             }),
-            BufferedOpenDrainRequest::AltForeverBlink => Self::AltForeverBlink(BlinkFsm {
-                state: true,
-                duration: timing.alt.high_ms,
-            }),
+            BufferedOpenDrainRequest::AltForeverBlink(x) => Self::AltForeverBlink(
+                BlinkFsm {
+                    state: true,
+                    duration: timing.alt.high_ms,
+                },
+                x,
+            ),
         }
     }
 }
@@ -186,20 +316,22 @@ impl MicroHsm {
             Self::TickTock(fsm) => fsm
                 .try_substract(timing.shared.get(), elapsed)
                 .map_or(Self::default(), Self::TickTock),
-            Self::AltTickTock(fsm) => fsm
-                .try_substract(timing.alt, elapsed)
-                .map_or(Self::default(), Self::AltTickTock),
+            Self::AltTickTock(fsm, builtin_timing) => fsm
+                .try_substract(*builtin_timing, elapsed)
+                .map_or(Self::default(), |f| Self::AltTickTock(f, *builtin_timing)),
             Self::ForeverBlink(fsm) => {
                 Self::ForeverBlink(fsm.substract(timing.shared.get(), elapsed))
             }
-            Self::AltForeverBlink(fsm) => Self::AltForeverBlink(fsm.substract(timing.alt, elapsed)),
+            Self::AltForeverBlink(fsm, builtin_timing) => {
+                Self::AltForeverBlink(fsm.substract(*builtin_timing, elapsed), *builtin_timing)
+            }
         }
     }
 
     pub fn next_sched_time(&self) -> Option<u16> {
         match self {
-            Self::TickTock(fsm) | Self::AltTickTock(fsm) => Some(fsm.duration),
-            Self::ForeverBlink(fsm) | Self::AltForeverBlink(fsm) => Some(fsm.duration),
+            Self::TickTock(fsm) | Self::AltTickTock(fsm, _) => Some(fsm.duration),
+            Self::ForeverBlink(fsm) | Self::AltForeverBlink(fsm, _) => Some(fsm.duration),
             _ => None,
         }
     }
@@ -208,16 +340,18 @@ impl MicroHsm {
         match self {
             Self::SetLow => false,
             Self::SetHigh => true,
-            Self::TickTock(fsm) | Self::AltTickTock(fsm) => fsm.expect_output_pin_state(),
-            Self::ForeverBlink(fsm) | Self::AltForeverBlink(fsm) => fsm.expect_output_pin_state(),
+            Self::TickTock(fsm) | Self::AltTickTock(fsm, _) => fsm.expect_output_pin_state(),
+            Self::ForeverBlink(fsm) | Self::AltForeverBlink(fsm, _) => {
+                fsm.expect_output_pin_state()
+            }
         }
     }
 
     pub fn is_busy(&self) -> bool {
         match self {
             Self::SetHigh | Self::SetLow => false,
-            Self::TickTock(_) | Self::AltTickTock(_) => true,
-            Self::ForeverBlink(_) | Self::AltForeverBlink(_) => false,
+            Self::TickTock(_) | Self::AltTickTock(_, _) => true,
+            Self::ForeverBlink(_) | Self::AltForeverBlink(_, _) => false,
         }
     }
 }
@@ -281,12 +415,22 @@ impl BufferedOpenDrain {
                 }
             };
 
-            match request {
-                Ok(received) => {
-                    // replace slot
-                    hsm = (received, self.timing).into();
+            match request.map_or(None, |x| {
+                BufferedOpenDrainRequest::try_from(x).map_or_else(
+                    |e| {
+                        defmt::error!(
+                            "RawBufferedOpenDrainRequestTryIntoError : 0x{:04X}",
+                            e.inner
+                        );
+                        None
+                    },
+                    Some,
+                )
+            }) {
+                Some(y) => {
+                    hsm = (y, self.timing).into();
                 }
-                Err(_) => {
+                None => {
                     let elapsed = (Instant::now() - last).as_millis().min(u16::MAX.into()) as u16;
                     hsm = hsm.next(self.timing, elapsed);
                 }
@@ -298,12 +442,12 @@ impl BufferedOpenDrain {
     }
 
     pub async fn request(&self, request: BufferedOpenDrainRequest) {
-        self.channel_hsm.send(request).await
+        self.channel_hsm.send(request.into()).await
     }
 
     pub async fn try_request(&self, request: BufferedOpenDrainRequest) -> Result<(), ()> {
         self.channel_hsm
-            .try_send(request)
+            .try_send(request.into())
             .map_or(Err(()), |_| Ok(()))
     }
 
@@ -327,29 +471,52 @@ impl BufferedOpenDrain {
     }
 
     /// Simply order tick tock (high/low with shared duration configuration) on the opendrain module.
-    /// Not wait for being reflected and wait for sending queue.
+    /// Not wait for being reflected but wait for sending queue.
     pub async fn tick_tock(&self, count: u8) {
         self.request(BufferedOpenDrainRequest::TickTock(count))
             .await
     }
 
     /// Simply order tick tock (high/low with alt duration configuration) on the opendrain module.
-    /// Not wait for being reflected and wait for sending queue.
-    pub async fn alt_tick_tock(&self, count: u8) {
-        self.request(BufferedOpenDrainRequest::AltTickTock(count))
-            .await
+    /// Not wait for being reflected but wait for sending queue.
+    pub async fn alt_tick_tock(&self, count: u8, high_ms: u16, low_ms: u16) {
+        self.request(BufferedOpenDrainRequest::AltTickTock(AltTickTockRequest {
+            toggle_count: count,
+            timing: ToggleTiming { high_ms, low_ms },
+        }))
+        .await
+    }
+
+    /// Simply order tick tock (high/low with alt duration configuration) on the opendrain module.
+    /// Not wait for being reflected but wait for sending queue.
+    pub async fn alt_tick_tock_timing(&self, count: u8, timing: ToggleTiming) {
+        self.request(BufferedOpenDrainRequest::AltTickTock(AltTickTockRequest {
+            toggle_count: count,
+            timing,
+        }))
+        .await
     }
 
     /// Simply order blink forever (high/low with shared duration configuration) on the opendrain module.
-    /// Not wait for being reflected and wait for sending queue.
+    /// Not wait for being reflected but wait for sending queue.
     pub async fn forever_blink(&self) {
         self.request(BufferedOpenDrainRequest::ForeverBlink).await
     }
 
     /// Simply order blink forever (high/low with alt duration configuration) on the opendrain module.
-    /// Not wait for being reflected and wait for sending queue.
-    pub async fn alt_forever_blink(&self) {
-        self.request(BufferedOpenDrainRequest::AltForeverBlink)
+    /// Not wait for being reflected but wait for sending queue.
+    pub async fn alt_forever_blink(&self, high_ms: u16, low_ms: u16) {
+        self.request(BufferedOpenDrainRequest::AltForeverBlink(ToggleTiming {
+            high_ms,
+            low_ms,
+        }))
+        .await
+    }
+
+    /// Simply order blink forever (high/low with alt duration configuration) on the opendrain module.
+    /// Not wait for being reflected but wait for sending queue.
+    pub async fn alt_forever_blink_timing(&self, timing: ToggleTiming) {
+        self.request(BufferedOpenDrainRequest::AltForeverBlink(timing))
             .await
     }
 }

--- a/src/semi_layer/buffered_wait_receiver.rs
+++ b/src/semi_layer/buffered_wait_receiver.rs
@@ -12,7 +12,6 @@ use embassy_sync::channel::TryReceiveError;
 
 use super::buffered_wait::{InputEventChannel, InputEventKind, RawInputEvent};
 
-// #[allow(unused)]
 pub struct BufferedWaitReceiver {
     pub channel: InputEventChannel,
     bit_cache: Mutex<ThreadModeRawMutex, u16>,

--- a/src/semi_layer/timing.rs
+++ b/src/semi_layer/timing.rs
@@ -51,17 +51,3 @@ impl SharedToggleTiming {
 // Required to allow static SharedToggleTiming
 // see : https://docs.rust-embedded.org/book/concurrency/#abstractions-send-and-sync
 unsafe impl Sync for SharedToggleTiming {}
-
-pub struct DualPoleToggleTiming {
-    /// shared toggle timing, but not guaranteed ordering and something else.
-    pub shared: SharedToggleTiming,
-    /// prefer const-ish value (todo tided on const only)
-    /// alt field is not allowed modification on runtime.
-    pub alt: ToggleTiming,
-}
-
-impl DualPoleToggleTiming {
-    pub const fn new(shared: SharedToggleTiming, alt: ToggleTiming) -> DualPoleToggleTiming {
-        Self { shared, alt }
-    }
-}


### PR DESCRIPTION
### Issues
#1 

`toggle_count` is represented instead `signal_count`.
single pool `.bss` size is increased to **120**bytes from **112**bytes.
There's way to reduce again, but too many instruction will be executed.

### Definition of done
- [x] `AltForever` and `AltTickTock` redesign
- [x] Serdes for `RawBufferedOpenDrainRequest` <-> `BufferedOpenDrainRequest`
- [x] Fix `BufferedOpenDrainRequest` module implementation
- [x] Remove unused variable or define such as `DualPoleToggleTiming` and `alt: ToggleTiming`