### PR TITLE
Buffered OpenDrain/Wait debug ability enhancement

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -9,7 +9,23 @@
 # However, please note that currently, in the debug build, the flash section exceeds 32KB.
 # Therefore, this change will be applicable only for production use,
 # considering its benefits in the release build.
-runner = "probe-rs-cli run --chip STM32G030C8Tx"
+# runner = "probe-run --chip STM32G030C8Tx --host-log-format \"{t} [{L}] {f}:{l} {s}\""
+runner = [
+  "probe-run",
+  "--chip",
+  "STM32G030C8Tx",
+  "--log-format",
+  "{t} [{L}][ {f}:{l} ] {s}",
+]
+
+rustflags = [
+#   "-C", "linker=flip-link",
+#   "-C", "link-arg=-Tlink.x",
+  "-C", "link-arg=-Tdefmt.x",
+  # This is needed if your flash or ram addresses are not aligned to 0x10000 in memory.x
+  # See https://github.com/rust-embedded/cortex-m-quickstart/pull/95
+  "-C", "link-arg=--nmagic",
+]
 
 [build]
 target = "thumbv6m-none-eabi"
@@ -24,3 +40,9 @@ DEFMT_LOG = "trace"
 [patch.'https://github.com/pmnxis/billmock-app-rs.git']
 serial-arcade-pay = { path = "serial-arcade-pay" }
 serial-arcade-pay-impl = { path = "serial-arcade-example" }
+
+# Custom println! To use formatting, use the latest branch.
+# [patch.crates-io]
+# defmt = { git = "https://github.com/knurling-rs/defmt.git", rev = "ca161bf0ab9ea8209fa5b6781e9f4e87f592eb57" }
+# defmt-test = { git = "https://github.com/knurling-rs/defmt.git", rev = "ca161bf0ab9ea8209fa5b6781e9f4e87f592eb57" }
+# defmt-rtt = { git = "https://github.com/knurling-rs/defmt.git", rev = "ca161bf0ab9ea8209fa5b6781e9f4e87f592eb57" }

--- a/src/boards/billmock_0v2.rs
+++ b/src/boards/billmock_0v2.rs
@@ -26,6 +26,8 @@ use crate::components::serial_device::CardReaderDevice;
 use crate::components::vend_side_bill::VendSideBill;
 use crate::semi_layer::buffered_opendrain::BufferedOpenDrain;
 use crate::semi_layer::buffered_wait::InputPortKind;
+use crate::types::buffered_opendrain_kind::BufferedOpenDrainKind;
+use crate::types::player::Player;
 
 bind_interrupts!(struct Irqs {
     USART2 => embassy_stm32::usart::InterruptHandler<peripherals::USART2>;
@@ -69,6 +71,7 @@ pub fn hardware_init_0v2(
     Hardware {
         vend_sides: [
             VendSideBill::new(
+                Player::Player1,
                 Output::new(p.PB0.degrade(), Level::Low, Speed::Low), // REAL_INH
                 ExtiInput::new(
                     Input::new(p.PB2, Pull::None).degrade(), // REAL_VND
@@ -84,6 +87,7 @@ pub fn hardware_init_0v2(
                 &shared_resource.arcade_players_timing[PLAYER_1_INDEX],
             ),
             VendSideBill::new(
+                Player::Player2,
                 Output::new(p.PA1.degrade(), Level::Low, Speed::Low), // LED_STR1 (Temporary)
                 ExtiInput::new(
                     Input::new(p.PD1, Pull::None).degrade(), // REAL_STR1
@@ -101,6 +105,7 @@ pub fn hardware_init_0v2(
         ],
         host_sides: [
             HostSideBill::new(
+                Player::Player1,
                 ExtiInput::new(
                     Input::new(p.PD0, Pull::None).degrade(), // VIRT0_INH
                     p.EXTI0.degrade(),                       // EXTI0
@@ -114,6 +119,7 @@ pub fn hardware_init_0v2(
                 &shared_resource.arcade_players_timing[PLAYER_1_INDEX],
             ),
             HostSideBill::new(
+                Player::Player2,
                 ExtiInput::new(
                     Input::new(p.PA15, Pull::None).degrade(), // VIRT1_INH
                     p.EXTI15.degrade(),                       // EXTI15
@@ -131,10 +137,12 @@ pub fn hardware_init_0v2(
             BufferedOpenDrain::new(
                 Output::new(p.PA4.degrade(), Level::High, Speed::Low),
                 &shared_resource.indicator_timing,
+                BufferedOpenDrainKind::Indicator(1).const_str(),
             ),
             BufferedOpenDrain::new(
                 Output::new(p.PA5.degrade(), Level::High, Speed::Low),
                 &shared_resource.indicator_timing,
+                BufferedOpenDrainKind::Indicator(2).const_str(),
             ),
         ],
         dipsw: DipSwitch::new(

--- a/src/boards/billmock_0v2.rs
+++ b/src/boards/billmock_0v2.rs
@@ -25,7 +25,6 @@ use crate::components::serial_device::CardReaderDevice;
 // use crate::components::start_button::StartButton;
 use crate::components::vend_side_bill::VendSideBill;
 use crate::semi_layer::buffered_opendrain::BufferedOpenDrain;
-use crate::semi_layer::buffered_wait::InputPortKind;
 use crate::types::buffered_opendrain_kind::BufferedOpenDrainKind;
 use crate::types::player::Player;
 
@@ -77,12 +76,10 @@ pub fn hardware_init_0v2(
                     Input::new(p.PB2, Pull::None).degrade(), // REAL_VND
                     p.EXTI2.degrade(),                       // EXTI2
                 ),
-                InputPortKind::Vend1P,
                 ExtiInput::new(
                     Input::new(p.PB14, Pull::None).degrade(), // REAL_JAM (moved from PB15 at HW v0.3)
                     p.EXTI14.degrade(),                       // EXTI14
                 ),
-                InputPortKind::StartJam1P,
                 async_input_event_ch,
                 &shared_resource.arcade_players_timing[PLAYER_1_INDEX],
             ),
@@ -93,12 +90,10 @@ pub fn hardware_init_0v2(
                     Input::new(p.PD1, Pull::None).degrade(), // REAL_STR1
                     p.EXTI1.degrade(),                       // EXTI1
                 ),
-                InputPortKind::Vend2P,
                 ExtiInput::new(
                     Input::new(p.PB11, Pull::None).degrade(), // REAL_STR0
                     p.EXTI11.degrade(),                       // EXTI11
                 ),
-                InputPortKind::StartJam2P,
                 async_input_event_ch,
                 &shared_resource.arcade_players_timing[PLAYER_2_INDEX],
             ),
@@ -110,7 +105,6 @@ pub fn hardware_init_0v2(
                     Input::new(p.PD0, Pull::None).degrade(), // VIRT0_INH
                     p.EXTI0.degrade(),                       // EXTI0
                 ),
-                InputPortKind::Inhibit1P,
                 Output::new(p.PD3.degrade(), Level::Low, Speed::Low), // VIRT0_BSY
                 Output::new(p.PD2.degrade(), Level::Low, Speed::Low), // VIRT0_VND
                 Output::new(p.PB9.degrade(), Level::Low, Speed::Low), // VIRT0_JAM
@@ -124,7 +118,6 @@ pub fn hardware_init_0v2(
                     Input::new(p.PA15, Pull::None).degrade(), // VIRT1_INH
                     p.EXTI15.degrade(),                       // EXTI15
                 ),
-                InputPortKind::Inhibit2P,
                 Output::new(p.PB4.degrade(), Level::Low, Speed::Low), // VIRT1_BSY
                 Output::new(p.PC13.degrade(), Level::Low, Speed::Low), // VIRT1_VND
                 Output::new(p.PB8.degrade(), Level::Low, Speed::Low), // VIRT1_JAM

--- a/src/boards/billmock_0v3.rs
+++ b/src/boards/billmock_0v3.rs
@@ -23,7 +23,6 @@ use crate::components::serial_device::CardReaderDevice;
 use crate::components::vend_side_bill::VendSideBill;
 use crate::semi_layer::buffered_opendrain::BufferedOpenDrain;
 use crate::types::buffered_opendrain_kind::BufferedOpenDrainKind;
-use crate::types::input_port::InputPortKind;
 use crate::types::player::Player;
 
 bind_interrupts!(struct Irqs {
@@ -72,12 +71,10 @@ pub fn hardware_init_0v3(
                     Input::new(p.PB2, Pull::None).degrade(), // REAL0_VND
                     p.EXTI2.degrade(),                       // EXTI2
                 ),
-                InputPortKind::Vend1P,
                 ExtiInput::new(
                     Input::new(p.PB14, Pull::None).degrade(), // REAL0_STR
                     p.EXTI14.degrade(),                       // EXTI14
                 ),
-                InputPortKind::StartJam1P,
                 async_input_event_ch,
                 &shared_resource.arcade_players_timing[PLAYER_1_INDEX],
             ),
@@ -88,12 +85,10 @@ pub fn hardware_init_0v3(
                     Input::new(p.PB11, Pull::None).degrade(), // REAL1_VND
                     p.EXTI11.degrade(),                       // EXTI11 (HW 0.2 was EXTI1 with PD1)
                 ),
-                InputPortKind::Vend2P,
                 ExtiInput::new(
                     Input::new(p.PD1, Pull::None).degrade(), // REAL1_STR
                     p.EXTI1.degrade(),                       // EXTI1 (HW 0.2 was EXTI11 with PB11)
                 ),
-                InputPortKind::StartJam2P,
                 async_input_event_ch,
                 &shared_resource.arcade_players_timing[PLAYER_2_INDEX],
             ),
@@ -105,7 +100,6 @@ pub fn hardware_init_0v3(
                     Input::new(p.PD0, Pull::None).degrade(), // VIRT0_INH
                     p.EXTI0.degrade(),                       // EXTI0
                 ),
-                InputPortKind::Inhibit1P,
                 Output::new(p.PD3.degrade(), Level::Low, Speed::Low), // VIRT0_BSY
                 Output::new(p.PD2.degrade(), Level::Low, Speed::Low), // VIRT0_VND
                 Output::new(p.PB9.degrade(), Level::Low, Speed::Low), // VIRT0_JAM
@@ -119,7 +113,6 @@ pub fn hardware_init_0v3(
                     Input::new(p.PA15, Pull::None).degrade(), // VIRT1_INH
                     p.EXTI15.degrade(),                       // EXTI15
                 ),
-                InputPortKind::Inhibit2P,
                 Output::new(p.PB4.degrade(), Level::Low, Speed::Low), // VIRT1_BSY
                 Output::new(p.PC13.degrade(), Level::Low, Speed::Low), // VIRT1_VND
                 Output::new(p.PB8.degrade(), Level::Low, Speed::Low), // VIRT1_JAM

--- a/src/boards/billmock_0v3.rs
+++ b/src/boards/billmock_0v3.rs
@@ -132,12 +132,12 @@ pub fn hardware_init_0v3(
             BufferedOpenDrain::new(
                 Output::new(p.PA4.degrade(), Level::High, Speed::Low),
                 &shared_resource.indicator_timing,
-                BufferedOpenDrainKind::Indicator(0).const_str(),
+                BufferedOpenDrainKind::Indicator(1).const_str(),
             ),
             BufferedOpenDrain::new(
                 Output::new(p.PA5.degrade(), Level::High, Speed::Low),
                 &shared_resource.indicator_timing,
-                BufferedOpenDrainKind::Indicator(1).const_str(),
+                BufferedOpenDrainKind::Indicator(2).const_str(),
             ),
         ],
         dipsw: DipSwitch::new(

--- a/src/boards/billmock_0v3.rs
+++ b/src/boards/billmock_0v3.rs
@@ -22,7 +22,9 @@ use crate::components::host_side_bill::HostSideBill;
 use crate::components::serial_device::CardReaderDevice;
 use crate::components::vend_side_bill::VendSideBill;
 use crate::semi_layer::buffered_opendrain::BufferedOpenDrain;
+use crate::types::buffered_opendrain_kind::BufferedOpenDrainKind;
 use crate::types::input_port::InputPortKind;
+use crate::types::player::Player;
 
 bind_interrupts!(struct Irqs {
     USART2 => embassy_stm32::usart::InterruptHandler<peripherals::USART2>;
@@ -64,6 +66,7 @@ pub fn hardware_init_0v3(
     Hardware {
         vend_sides: [
             VendSideBill::new(
+                Player::Player1,
                 Output::new(p.PA1.degrade(), Level::Low, Speed::Low), // REAL0_INH
                 ExtiInput::new(
                     Input::new(p.PB2, Pull::None).degrade(), // REAL0_VND
@@ -79,6 +82,7 @@ pub fn hardware_init_0v3(
                 &shared_resource.arcade_players_timing[PLAYER_1_INDEX],
             ),
             VendSideBill::new(
+                Player::Player2,
                 Output::new(p.PA0.degrade(), Level::Low, Speed::Low), // REAL1_INH
                 ExtiInput::new(
                     Input::new(p.PB11, Pull::None).degrade(), // REAL1_VND
@@ -96,6 +100,7 @@ pub fn hardware_init_0v3(
         ],
         host_sides: [
             HostSideBill::new(
+                Player::Player1,
                 ExtiInput::new(
                     Input::new(p.PD0, Pull::None).degrade(), // VIRT0_INH
                     p.EXTI0.degrade(),                       // EXTI0
@@ -109,6 +114,7 @@ pub fn hardware_init_0v3(
                 &shared_resource.arcade_players_timing[PLAYER_1_INDEX],
             ),
             HostSideBill::new(
+                Player::Player2,
                 ExtiInput::new(
                     Input::new(p.PA15, Pull::None).degrade(), // VIRT1_INH
                     p.EXTI15.degrade(),                       // EXTI15
@@ -126,10 +132,12 @@ pub fn hardware_init_0v3(
             BufferedOpenDrain::new(
                 Output::new(p.PA4.degrade(), Level::High, Speed::Low),
                 &shared_resource.indicator_timing,
+                BufferedOpenDrainKind::Indicator(0).const_str(),
             ),
             BufferedOpenDrain::new(
                 Output::new(p.PA5.degrade(), Level::High, Speed::Low),
                 &shared_resource.indicator_timing,
+                BufferedOpenDrainKind::Indicator(1).const_str(),
             ),
         ],
         dipsw: DipSwitch::new(

--- a/src/components/host_side_bill.rs
+++ b/src/components/host_side_bill.rs
@@ -12,8 +12,10 @@ use embassy_stm32::gpio::{AnyPin, Output};
 use crate::semi_layer::buffered_opendrain::{buffered_opendrain_spawn, BufferedOpenDrain};
 use crate::semi_layer::buffered_wait::{buffered_wait_spawn, BufferedWait, InputEventChannel};
 use crate::semi_layer::timing::SharedToggleTiming;
+use crate::types::buffered_opendrain_kind::BufferedOpenDrainKind;
 use crate::types::const_convert::ConstInto;
 use crate::types::input_port::InputPortKind;
+use crate::types::player::Player;
 
 pub struct HostSideBill {
     in_inhibit: BufferedWait,
@@ -25,6 +27,7 @@ pub struct HostSideBill {
 
 impl HostSideBill {
     pub const fn new(
+        player: Player,
         in_inhibit: ExtiInput<'static, AnyPin>,
         in_inhibit_event: InputPortKind,
         out_busy: Output<'static, AnyPin>,
@@ -34,12 +37,17 @@ impl HostSideBill {
         mpsc_ch: &'static InputEventChannel,
         shared_timing: &'static SharedToggleTiming,
     ) -> Self {
+        let busy_str: &'static str = BufferedOpenDrainKind::HostSideOutBusy(player).const_str();
+        let vend_str: &'static str = BufferedOpenDrainKind::HostSideOutVend(player).const_str();
+        let jam_str: &'static str = BufferedOpenDrainKind::HostSideOutJam(player).const_str();
+        let start_str: &'static str = BufferedOpenDrainKind::HostSideOutStart(player).const_str();
+
         Self {
             in_inhibit: BufferedWait::new(in_inhibit, in_inhibit_event.const_into(), mpsc_ch),
-            out_busy: BufferedOpenDrain::new(out_busy, shared_timing),
-            out_vend: BufferedOpenDrain::new(out_vend, shared_timing),
-            out_jam: BufferedOpenDrain::new(out_jam, shared_timing),
-            out_start: BufferedOpenDrain::new(out_start, shared_timing),
+            out_busy: BufferedOpenDrain::new(out_busy, shared_timing, busy_str),
+            out_vend: BufferedOpenDrain::new(out_vend, shared_timing, vend_str),
+            out_jam: BufferedOpenDrain::new(out_jam, shared_timing, jam_str),
+            out_start: BufferedOpenDrain::new(out_start, shared_timing, start_str),
         }
     }
 

--- a/src/components/host_side_bill.rs
+++ b/src/components/host_side_bill.rs
@@ -10,10 +10,10 @@ use embassy_stm32::exti::ExtiInput;
 use embassy_stm32::gpio::{AnyPin, Output};
 
 use crate::semi_layer::buffered_opendrain::{buffered_opendrain_spawn, BufferedOpenDrain};
-use crate::semi_layer::buffered_wait::{buffered_wait_spawn, BufferedWait, InputEventChannel};
+use crate::semi_layer::buffered_wait::buffered_wait_spawn;
+use crate::semi_layer::buffered_wait::{BufferedWait, InputEventChannel, RawInputPortKind};
 use crate::semi_layer::timing::SharedToggleTiming;
 use crate::types::buffered_opendrain_kind::BufferedOpenDrainKind;
-use crate::types::const_convert::ConstInto;
 use crate::types::input_port::InputPortKind;
 use crate::types::player::Player;
 
@@ -29,7 +29,6 @@ impl HostSideBill {
     pub const fn new(
         player: Player,
         in_inhibit: ExtiInput<'static, AnyPin>,
-        in_inhibit_event: InputPortKind,
         out_busy: Output<'static, AnyPin>,
         out_vend: Output<'static, AnyPin>,
         out_jam: Output<'static, AnyPin>,
@@ -37,13 +36,15 @@ impl HostSideBill {
         mpsc_ch: &'static InputEventChannel,
         shared_timing: &'static SharedToggleTiming,
     ) -> Self {
+        let (inh_p, inh_str): (RawInputPortKind, &'static str) =
+            InputPortKind::Inhibit1P.to_raw_and_const_str(player);
         let busy_str: &'static str = BufferedOpenDrainKind::HostSideOutBusy(player).const_str();
         let vend_str: &'static str = BufferedOpenDrainKind::HostSideOutVend(player).const_str();
         let jam_str: &'static str = BufferedOpenDrainKind::HostSideOutJam(player).const_str();
         let start_str: &'static str = BufferedOpenDrainKind::HostSideOutStart(player).const_str();
 
         Self {
-            in_inhibit: BufferedWait::new(in_inhibit, in_inhibit_event.const_into(), mpsc_ch),
+            in_inhibit: BufferedWait::new(in_inhibit, mpsc_ch, inh_p, inh_str),
             out_busy: BufferedOpenDrain::new(out_busy, shared_timing, busy_str),
             out_vend: BufferedOpenDrain::new(out_vend, shared_timing, vend_str),
             out_jam: BufferedOpenDrain::new(out_jam, shared_timing, jam_str),

--- a/src/components/start_button.rs
+++ b/src/components/start_button.rs
@@ -10,10 +10,10 @@ use embassy_stm32::exti::ExtiInput;
 use embassy_stm32::gpio::{AnyPin, Output};
 
 use crate::semi_layer::buffered_opendrain::{buffered_opendrain_spawn, BufferedOpenDrain};
-use crate::semi_layer::buffered_wait::{buffered_wait_spawn, BufferedWait, InputEventChannel};
+use crate::semi_layer::buffered_wait::buffered_wait_spawn;
+use crate::semi_layer::buffered_wait::{BufferedWait, InputEventChannel, RawInputPortKind};
 use crate::semi_layer::timing::SharedToggleTiming;
 use crate::types::buffered_opendrain_kind::BufferedOpenDrainKind;
-use crate::types::const_convert::ConstInto;
 use crate::types::input_port::InputPortKind;
 use crate::types::player::Player;
 /// deprecated from hardware version 0.3
@@ -28,15 +28,16 @@ impl StartButton {
     pub const fn new(
         player: Player,
         in_switch: ExtiInput<'static, AnyPin>,
-        in_switch_event: InputPortKind,
         out_led: Output<'static, AnyPin>,
         mpsc_ch: &'static InputEventChannel,
         shared_timing: &'static SharedToggleTiming,
     ) -> Self {
         let led_str: &'static str = BufferedOpenDrainKind::VendSideStartLed(player).const_str();
+        let (snj_p, snj_str): (RawInputPortKind, &'static str) =
+            InputPortKind::StartJam1P.to_raw_and_const_str(player);
 
         Self {
-            in_switch: BufferedWait::new(in_switch, in_switch_event.const_into(), mpsc_ch),
+            in_switch: BufferedWait::new(in_switch, mpsc_ch, snj_p, snj_str),
             out_led: BufferedOpenDrain::new(out_led, shared_timing, led_str),
         }
     }

--- a/src/components/start_button.rs
+++ b/src/components/start_button.rs
@@ -12,9 +12,10 @@ use embassy_stm32::gpio::{AnyPin, Output};
 use crate::semi_layer::buffered_opendrain::{buffered_opendrain_spawn, BufferedOpenDrain};
 use crate::semi_layer::buffered_wait::{buffered_wait_spawn, BufferedWait, InputEventChannel};
 use crate::semi_layer::timing::SharedToggleTiming;
+use crate::types::buffered_opendrain_kind::BufferedOpenDrainKind;
 use crate::types::const_convert::ConstInto;
 use crate::types::input_port::InputPortKind;
-
+use crate::types::player::Player;
 /// deprecated from hardware version 0.3
 #[allow(dead_code)]
 pub struct StartButton {
@@ -25,15 +26,18 @@ pub struct StartButton {
 #[allow(dead_code)]
 impl StartButton {
     pub const fn new(
+        player: Player,
         in_switch: ExtiInput<'static, AnyPin>,
         in_switch_event: InputPortKind,
         out_led: Output<'static, AnyPin>,
         mpsc_ch: &'static InputEventChannel,
         shared_timing: &'static SharedToggleTiming,
     ) -> Self {
+        let led_str: &'static str = BufferedOpenDrainKind::VendSideStartLed(player).const_str();
+
         Self {
             in_switch: BufferedWait::new(in_switch, in_switch_event.const_into(), mpsc_ch),
-            out_led: BufferedOpenDrain::new(out_led, shared_timing),
+            out_led: BufferedOpenDrain::new(out_led, shared_timing, led_str),
         }
     }
 

--- a/src/components/vend_side_bill.rs
+++ b/src/components/vend_side_bill.rs
@@ -12,8 +12,10 @@ use embassy_stm32::gpio::{AnyPin, Output};
 use crate::semi_layer::buffered_opendrain::{buffered_opendrain_spawn, BufferedOpenDrain};
 use crate::semi_layer::buffered_wait::{buffered_wait_spawn, BufferedWait, InputEventChannel};
 use crate::semi_layer::timing::SharedToggleTiming;
+use crate::types::buffered_opendrain_kind::BufferedOpenDrainKind;
 use crate::types::const_convert::ConstInto;
 use crate::types::input_port::InputPortKind;
+use crate::types::player::Player;
 
 pub struct VendSideBill {
     pub out_inhibit: BufferedOpenDrain,
@@ -23,6 +25,7 @@ pub struct VendSideBill {
 
 impl VendSideBill {
     pub const fn new(
+        player: Player,
         out_inhibit: Output<'static, AnyPin>,
         in_vend: ExtiInput<'static, AnyPin>,
         in_vend_event: InputPortKind,
@@ -31,8 +34,10 @@ impl VendSideBill {
         mpsc_ch: &'static InputEventChannel,
         shared_timing: &'static SharedToggleTiming,
     ) -> VendSideBill {
+        let vend_str: &'static str = BufferedOpenDrainKind::VendSideInhibit(player).const_str();
+
         Self {
-            out_inhibit: BufferedOpenDrain::new(out_inhibit, shared_timing),
+            out_inhibit: BufferedOpenDrain::new(out_inhibit, shared_timing, vend_str),
             in_vend: BufferedWait::new(in_vend, in_vend_event.const_into(), mpsc_ch),
             in_start_jam: BufferedWait::new(in_start_jam, in_start_jam_event.const_into(), mpsc_ch),
         }

--- a/src/components/vend_side_bill.rs
+++ b/src/components/vend_side_bill.rs
@@ -10,10 +10,10 @@ use embassy_stm32::exti::ExtiInput;
 use embassy_stm32::gpio::{AnyPin, Output};
 
 use crate::semi_layer::buffered_opendrain::{buffered_opendrain_spawn, BufferedOpenDrain};
-use crate::semi_layer::buffered_wait::{buffered_wait_spawn, BufferedWait, InputEventChannel};
+use crate::semi_layer::buffered_wait::buffered_wait_spawn;
+use crate::semi_layer::buffered_wait::{BufferedWait, InputEventChannel, RawInputPortKind};
 use crate::semi_layer::timing::SharedToggleTiming;
 use crate::types::buffered_opendrain_kind::BufferedOpenDrainKind;
-use crate::types::const_convert::ConstInto;
 use crate::types::input_port::InputPortKind;
 use crate::types::player::Player;
 
@@ -28,18 +28,20 @@ impl VendSideBill {
         player: Player,
         out_inhibit: Output<'static, AnyPin>,
         in_vend: ExtiInput<'static, AnyPin>,
-        in_vend_event: InputPortKind,
         in_start_jam: ExtiInput<'static, AnyPin>,
-        in_start_jam_event: InputPortKind,
         mpsc_ch: &'static InputEventChannel,
         shared_timing: &'static SharedToggleTiming,
     ) -> VendSideBill {
-        let vend_str: &'static str = BufferedOpenDrainKind::VendSideInhibit(player).const_str();
+        let inhibit_str: &'static str = BufferedOpenDrainKind::VendSideInhibit(player).const_str();
+        let (vend_p, vend_str): (RawInputPortKind, &'static str) =
+            InputPortKind::Vend1P.to_raw_and_const_str(player);
+        let (snj_p, snj_str): (RawInputPortKind, &'static str) =
+            InputPortKind::StartJam1P.to_raw_and_const_str(player);
 
         Self {
-            out_inhibit: BufferedOpenDrain::new(out_inhibit, shared_timing, vend_str),
-            in_vend: BufferedWait::new(in_vend, in_vend_event.const_into(), mpsc_ch),
-            in_start_jam: BufferedWait::new(in_start_jam, in_start_jam_event.const_into(), mpsc_ch),
+            out_inhibit: BufferedOpenDrain::new(out_inhibit, shared_timing, inhibit_str),
+            in_vend: BufferedWait::new(in_vend, mpsc_ch, vend_p, vend_str),
+            in_start_jam: BufferedWait::new(in_start_jam, mpsc_ch, snj_p, snj_str),
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,6 @@ mod components;
 mod semi_layer;
 mod types;
 
-use defmt::*;
 use embassy_executor::Spawner;
 use embassy_time::{Duration, Timer};
 use static_cell::make_static;
@@ -36,7 +35,7 @@ async fn main(spawner: Spawner) {
     // Spawns a task bound to the BSP
     board.start_tasks(&spawner);
 
-    info!("Hello BillMock");
+    defmt::info!("Hello BillMock");
 
     let application = Application::new(board);
     application.main_task().await;

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,11 +29,14 @@ async fn main(spawner: Spawner) {
     // Initialize necessary BSP
     let board: &'static mut Board = make_static!(Board::init());
 
-    // few wait for stablize external electronic status
-    Timer::after(Duration::from_secs(1)).await;
+    // heuristic wait for stablize external electronic status
+    Timer::after(Duration::from_millis(1000)).await;
 
     // Spawns a task bound to the BSP
     board.start_tasks(&spawner);
+
+    // heuristic wait for stablize task spawning
+    Timer::after(Duration::from_millis(500)).await;
 
     defmt::info!("Hello BillMock");
 

--- a/src/semi_layer/buffered_opendrain.rs
+++ b/src/semi_layer/buffered_opendrain.rs
@@ -371,12 +371,10 @@ pub struct BufferedOpenDrain {
 impl BufferedOpenDrain {
     fn reflect_on_io(&self, hsm: &MicroHsm) {
         let io = unsafe { &mut *self.io.get() };
-
         let state: Level = hsm.expect_output_pin_state().into();
+
         #[cfg(debug_assertions)]
-        {
-            defmt::println!("OUT[{}] : {}", self.debug_name, state);
-        }
+        defmt::println!("OUT[{}] : {}", self.debug_name, state);
 
         io.set_level(state);
     }

--- a/src/semi_layer/buffered_opendrain.rs
+++ b/src/semi_layer/buffered_opendrain.rs
@@ -361,24 +361,31 @@ pub struct BufferedOpenDrain {
     io: UnsafeCell<Output<'static, AnyPin>>,
     shared_timing: &'static SharedToggleTiming,
     channel_hsm: OpenDrainRequestChannel,
+
+    /// only use for debug print
+    #[cfg(debug_assertions)]
+    debug_name: &'static str,
 }
 
 #[allow(unused)]
 impl BufferedOpenDrain {
     fn reflect_on_io(&self, hsm: &MicroHsm) {
         let io = unsafe { &mut *self.io.get() };
-
+        defmt::info!("OUT[] : {}", hsm.expect_output_pin_state() as bool);
         io.set_level(hsm.expect_output_pin_state().into());
     }
 
     pub const fn new(
         out_pin: Output<'static, AnyPin>,
         shared_timing: &'static SharedToggleTiming,
+        debug_name: &'static str,
     ) -> Self {
         Self {
             io: UnsafeCell::new(out_pin),
             shared_timing,
             channel_hsm: Channel::new(),
+            #[cfg(debug_assertions)]
+            debug_name,
         }
     }
 

--- a/src/semi_layer/buffered_opendrain.rs
+++ b/src/semi_layer/buffered_opendrain.rs
@@ -7,7 +7,7 @@
 use core::cell::UnsafeCell;
 
 use bit_field::BitField;
-use embassy_stm32::gpio::{AnyPin, Output};
+use embassy_stm32::gpio::{AnyPin, Level, Output};
 use embassy_sync::blocking_mutex::raw::ThreadModeRawMutex;
 use embassy_sync::channel::Channel;
 use embassy_time::{with_timeout, Duration, Instant, Timer};
@@ -371,8 +371,14 @@ pub struct BufferedOpenDrain {
 impl BufferedOpenDrain {
     fn reflect_on_io(&self, hsm: &MicroHsm) {
         let io = unsafe { &mut *self.io.get() };
-        defmt::info!("OUT[] : {}", hsm.expect_output_pin_state() as bool);
-        io.set_level(hsm.expect_output_pin_state().into());
+
+        let state: Level = hsm.expect_output_pin_state().into();
+        #[cfg(debug_assertions)]
+        {
+            defmt::println!("OUT[{}] : {}", self.debug_name, state);
+        }
+
+        io.set_level(state);
     }
 
     pub const fn new(

--- a/src/types/buffered_opendrain_kind.rs
+++ b/src/types/buffered_opendrain_kind.rs
@@ -7,21 +7,43 @@
 use crate::types::const_convert::ConstInto;
 use crate::types::player::Player;
 
-pub const OUTPUT_NAME_STRS: [&str; 15] = [
-    "P1_HostSideOut-Busy", // 0
-    "P2_HostSideOut-Busy",
-    "P1_HostSideOut-Vend", // 2
-    "P2_HostSideOut-Vend",
-    "P1_HostSideOut-Jam", // 4
-    "P2_HostSideOut-Jam",
-    "P1_HostSideOut-Start", // 6
-    "P2_HostSideOut-Start",
-    "P1_VendSideOut-Inhibit", // 8
-    "P2_VendSideOut-Inhibit",
-    "P1_VendSideOut-StartLED", // 10, would be not use
-    "P2_VendSideOut-StartLED", // would be not use
-    "LED1-Indicator",          // 12
-    "LED2-Indicator",
+#[cfg(debug_assertions)]
+const OUTPUT_NAME_STRS: [&str; 15] = [
+    "HostOut_P1-    Busy", // 0
+    "HostOut_P2-    Busy",
+    "HostOut_P1-    Vend", // 2
+    "HostOut_P2-    Vend",
+    "HostOut_P1-     Jam", // 4
+    "HostOut_P2-     Jam",
+    "HostOut_P1-   Start", // 6
+    "HostOut_P2-   Start",
+    "VendOut_P1- Inhibit", // 8
+    "VendOut_P2- Inhibit",
+    "VendOut_P1-StartLED", // 10, would be not use
+    "VendOut_P2-StartLED", // would be not use
+    "     LED1-Indicator", // 12
+    "     LED2-Indicator",
+    "Unknown",
+];
+
+#[cfg(not(debug_assertions))]
+#[rustfmt::skip]
+/// reduced output names
+const OUTPUT_NAME_STRS: [&str; 15] = [
+    "P1H-oBSY", // 0
+    "P2H-oBSY",
+    "P1H-oVND", // 2
+    "P2H-oVND",
+    "P1H-oJAM", // 4
+    "P2H-oJAM",
+    "P1H-oSTR", // 6
+    "P2H-oSTR",
+    "P1V-oINH", // 8
+    "P2V-oINH",
+    "P1V-oSLD", // 10, would be not use
+    "P2V-oSLD", // would be not use
+    "LED1",     // 12
+    "LED2",
     "Unknown",
 ];
 
@@ -37,71 +59,59 @@ pub enum BufferedOpenDrainKind {
     Unknown,
 }
 
-impl ConstInto<&'static str> for BufferedOpenDrainKind {
-    fn const_into(self) -> &'static str {
-        // hard-code is efficient in this case
-        match self {
-            Self::HostSideOutBusy(Player::Player1) => OUTPUT_NAME_STRS[0],
-            Self::HostSideOutBusy(Player::Player2) => OUTPUT_NAME_STRS[1],
-            Self::HostSideOutVend(Player::Player1) => OUTPUT_NAME_STRS[2],
-            Self::HostSideOutVend(Player::Player2) => OUTPUT_NAME_STRS[3],
-            Self::HostSideOutJam(Player::Player1) => OUTPUT_NAME_STRS[4],
-            Self::HostSideOutJam(Player::Player2) => OUTPUT_NAME_STRS[5],
-            Self::HostSideOutStart(Player::Player1) => OUTPUT_NAME_STRS[6],
-            Self::HostSideOutStart(Player::Player2) => OUTPUT_NAME_STRS[7],
-            Self::VendSideInhibit(Player::Player1) => OUTPUT_NAME_STRS[8],
-            Self::VendSideInhibit(Player::Player2) => OUTPUT_NAME_STRS[9],
-            Self::VendSideStartLed(Player::Player1) => OUTPUT_NAME_STRS[10],
-            Self::VendSideStartLed(Player::Player2) => OUTPUT_NAME_STRS[11],
-            Self::Indicator(0) => OUTPUT_NAME_STRS[12],
-            Self::Indicator(1) => OUTPUT_NAME_STRS[13],
-            _ => OUTPUT_NAME_STRS[14],
-        }
-    }
-}
-
 impl ConstInto<&'static str> for &BufferedOpenDrainKind {
     fn const_into(self) -> &'static str {
-        // hard-code is efficient in this case
-        match self {
-            BufferedOpenDrainKind::HostSideOutBusy(Player::Player1) => OUTPUT_NAME_STRS[0],
-            BufferedOpenDrainKind::HostSideOutBusy(Player::Player2) => OUTPUT_NAME_STRS[1],
-            BufferedOpenDrainKind::HostSideOutVend(Player::Player1) => OUTPUT_NAME_STRS[2],
-            BufferedOpenDrainKind::HostSideOutVend(Player::Player2) => OUTPUT_NAME_STRS[3],
-            BufferedOpenDrainKind::HostSideOutJam(Player::Player1) => OUTPUT_NAME_STRS[4],
-            BufferedOpenDrainKind::HostSideOutJam(Player::Player2) => OUTPUT_NAME_STRS[5],
-            BufferedOpenDrainKind::HostSideOutStart(Player::Player1) => OUTPUT_NAME_STRS[6],
-            BufferedOpenDrainKind::HostSideOutStart(Player::Player2) => OUTPUT_NAME_STRS[7],
-            BufferedOpenDrainKind::VendSideInhibit(Player::Player1) => OUTPUT_NAME_STRS[8],
-            BufferedOpenDrainKind::VendSideInhibit(Player::Player2) => OUTPUT_NAME_STRS[9],
-            BufferedOpenDrainKind::VendSideStartLed(Player::Player1) => OUTPUT_NAME_STRS[10],
-            BufferedOpenDrainKind::VendSideStartLed(Player::Player2) => OUTPUT_NAME_STRS[11],
-            BufferedOpenDrainKind::Indicator(0) => OUTPUT_NAME_STRS[12],
-            BufferedOpenDrainKind::Indicator(1) => OUTPUT_NAME_STRS[13],
-            _ => OUTPUT_NAME_STRS[14],
-        }
+        OUTPUT_NAME_STRS[self.get_str_idx()]
     }
 }
 
 impl BufferedOpenDrainKind {
+    pub const fn get_str_idx(&self) -> usize {
+        /*
+            // following code consume 444 bytes additionaly
+            match self {
+                Self::HostSideOutBusy(Player::Player1) => 0,
+                Self::HostSideOutBusy(Player::Player2) => 1,
+                Self::HostSideOutVend(Player::Player1) => 2,
+                Self::HostSideOutVend(Player::Player2) => 3,
+                Self::HostSideOutJam(Player::Player1) => 4,
+                Self::HostSideOutJam(Player::Player2) => 5,
+                Self::HostSideOutStart(Player::Player1) => 6,
+                Self::HostSideOutStart(Player::Player2) => 7,
+                Self::VendSideInhibit(Player::Player1) => 8,
+                Self::VendSideInhibit(Player::Player2) => 9,
+                Self::VendSideStartLed(Player::Player1) => 10,
+                Self::VendSideStartLed(Player::Player2) => 11,
+                Self::Indicator(0) => 12,
+                Self::Indicator(1) => 13,
+                _ => 14,
+            }
+        */
+
+        let (a, b): (u8, u8) = match self {
+            Self::HostSideOutBusy(p) => (0, *p as u8),
+            Self::HostSideOutVend(p) => (2, *p as u8),
+            Self::HostSideOutJam(p) => (4, *p as u8),
+            Self::HostSideOutStart(p) => (6, *p as u8),
+            Self::VendSideInhibit(p) => (8, *p as u8),
+            Self::VendSideStartLed(p) => (10, *p as u8),
+            Self::Indicator(p) => (12, *p),
+            _ => (14, 0),
+        };
+
+        // cannot use alpha.max(beta) in const fn
+        let b = if b == 0 {
+            1
+        } else if 2 < b {
+            2
+        } else {
+            b
+        };
+        (a + b - 1) as usize
+    }
+
     pub const fn const_str(&self) -> &'static str {
-        match self {
-            BufferedOpenDrainKind::HostSideOutBusy(Player::Player1) => OUTPUT_NAME_STRS[0],
-            BufferedOpenDrainKind::HostSideOutBusy(Player::Player2) => OUTPUT_NAME_STRS[1],
-            BufferedOpenDrainKind::HostSideOutVend(Player::Player1) => OUTPUT_NAME_STRS[2],
-            BufferedOpenDrainKind::HostSideOutVend(Player::Player2) => OUTPUT_NAME_STRS[3],
-            BufferedOpenDrainKind::HostSideOutJam(Player::Player1) => OUTPUT_NAME_STRS[4],
-            BufferedOpenDrainKind::HostSideOutJam(Player::Player2) => OUTPUT_NAME_STRS[5],
-            BufferedOpenDrainKind::HostSideOutStart(Player::Player1) => OUTPUT_NAME_STRS[6],
-            BufferedOpenDrainKind::HostSideOutStart(Player::Player2) => OUTPUT_NAME_STRS[7],
-            BufferedOpenDrainKind::VendSideInhibit(Player::Player1) => OUTPUT_NAME_STRS[8],
-            BufferedOpenDrainKind::VendSideInhibit(Player::Player2) => OUTPUT_NAME_STRS[9],
-            BufferedOpenDrainKind::VendSideStartLed(Player::Player1) => OUTPUT_NAME_STRS[10],
-            BufferedOpenDrainKind::VendSideStartLed(Player::Player2) => OUTPUT_NAME_STRS[11],
-            BufferedOpenDrainKind::Indicator(0) => OUTPUT_NAME_STRS[12],
-            BufferedOpenDrainKind::Indicator(1) => OUTPUT_NAME_STRS[13],
-            _ => OUTPUT_NAME_STRS[14],
-        }
+        OUTPUT_NAME_STRS[self.get_str_idx()]
     }
 }
 

--- a/src/types/buffered_opendrain_kind.rs
+++ b/src/types/buffered_opendrain_kind.rs
@@ -1,0 +1,116 @@
+/*
+ * SPDX-FileCopyrightText: © 2023 Jinwoo Park (pmnxis@gmail.com)
+ *
+ * SPDX-License-Identifier: MIT OR Apache-2.0
+ */
+
+use crate::types::const_convert::ConstInto;
+use crate::types::player::Player;
+
+pub const OUTPUT_NAME_STRS: [&str; 15] = [
+    "P1_HostSideOut-Busy", // 0
+    "P2_HostSideOut-Busy",
+    "P1_HostSideOut-Vend", // 2
+    "P2_HostSideOut-Vend",
+    "P1_HostSideOut-Jam", // 4
+    "P2_HostSideOut-Jam",
+    "P1_HostSideOut-Start", // 6
+    "P2_HostSideOut-Start",
+    "P1_VendSideOut-Inhibit", // 8
+    "P2_VendSideOut-Inhibit",
+    "P1_VendSideOut-StartLED", // 10, would be not use
+    "P2_VendSideOut-StartLED", // would be not use
+    "LED1-Indicator",          // 12
+    "LED2-Indicator",
+    "Unknown",
+];
+
+#[allow(unused)]
+pub enum BufferedOpenDrainKind {
+    HostSideOutBusy(Player),
+    HostSideOutVend(Player),
+    HostSideOutJam(Player),
+    HostSideOutStart(Player),
+    VendSideInhibit(Player),
+    VendSideStartLed(Player), // deprecated in 0.3
+    Indicator(u8),
+    Unknown,
+}
+
+impl ConstInto<&'static str> for BufferedOpenDrainKind {
+    fn const_into(self) -> &'static str {
+        // hard-code is efficient in this case
+        match self {
+            Self::HostSideOutBusy(Player::Player1) => OUTPUT_NAME_STRS[0],
+            Self::HostSideOutBusy(Player::Player2) => OUTPUT_NAME_STRS[1],
+            Self::HostSideOutVend(Player::Player1) => OUTPUT_NAME_STRS[2],
+            Self::HostSideOutVend(Player::Player2) => OUTPUT_NAME_STRS[3],
+            Self::HostSideOutJam(Player::Player1) => OUTPUT_NAME_STRS[4],
+            Self::HostSideOutJam(Player::Player2) => OUTPUT_NAME_STRS[5],
+            Self::HostSideOutStart(Player::Player1) => OUTPUT_NAME_STRS[6],
+            Self::HostSideOutStart(Player::Player2) => OUTPUT_NAME_STRS[7],
+            Self::VendSideInhibit(Player::Player1) => OUTPUT_NAME_STRS[8],
+            Self::VendSideInhibit(Player::Player2) => OUTPUT_NAME_STRS[9],
+            Self::VendSideStartLed(Player::Player1) => OUTPUT_NAME_STRS[10],
+            Self::VendSideStartLed(Player::Player2) => OUTPUT_NAME_STRS[11],
+            Self::Indicator(0) => OUTPUT_NAME_STRS[12],
+            Self::Indicator(1) => OUTPUT_NAME_STRS[13],
+            _ => OUTPUT_NAME_STRS[14],
+        }
+    }
+}
+
+impl ConstInto<&'static str> for &BufferedOpenDrainKind {
+    fn const_into(self) -> &'static str {
+        // hard-code is efficient in this case
+        match self {
+            BufferedOpenDrainKind::HostSideOutBusy(Player::Player1) => OUTPUT_NAME_STRS[0],
+            BufferedOpenDrainKind::HostSideOutBusy(Player::Player2) => OUTPUT_NAME_STRS[1],
+            BufferedOpenDrainKind::HostSideOutVend(Player::Player1) => OUTPUT_NAME_STRS[2],
+            BufferedOpenDrainKind::HostSideOutVend(Player::Player2) => OUTPUT_NAME_STRS[3],
+            BufferedOpenDrainKind::HostSideOutJam(Player::Player1) => OUTPUT_NAME_STRS[4],
+            BufferedOpenDrainKind::HostSideOutJam(Player::Player2) => OUTPUT_NAME_STRS[5],
+            BufferedOpenDrainKind::HostSideOutStart(Player::Player1) => OUTPUT_NAME_STRS[6],
+            BufferedOpenDrainKind::HostSideOutStart(Player::Player2) => OUTPUT_NAME_STRS[7],
+            BufferedOpenDrainKind::VendSideInhibit(Player::Player1) => OUTPUT_NAME_STRS[8],
+            BufferedOpenDrainKind::VendSideInhibit(Player::Player2) => OUTPUT_NAME_STRS[9],
+            BufferedOpenDrainKind::VendSideStartLed(Player::Player1) => OUTPUT_NAME_STRS[10],
+            BufferedOpenDrainKind::VendSideStartLed(Player::Player2) => OUTPUT_NAME_STRS[11],
+            BufferedOpenDrainKind::Indicator(0) => OUTPUT_NAME_STRS[12],
+            BufferedOpenDrainKind::Indicator(1) => OUTPUT_NAME_STRS[13],
+            _ => OUTPUT_NAME_STRS[14],
+        }
+    }
+}
+
+impl BufferedOpenDrainKind {
+    pub const fn const_str(&self) -> &'static str {
+        match self {
+            BufferedOpenDrainKind::HostSideOutBusy(Player::Player1) => OUTPUT_NAME_STRS[0],
+            BufferedOpenDrainKind::HostSideOutBusy(Player::Player2) => OUTPUT_NAME_STRS[1],
+            BufferedOpenDrainKind::HostSideOutVend(Player::Player1) => OUTPUT_NAME_STRS[2],
+            BufferedOpenDrainKind::HostSideOutVend(Player::Player2) => OUTPUT_NAME_STRS[3],
+            BufferedOpenDrainKind::HostSideOutJam(Player::Player1) => OUTPUT_NAME_STRS[4],
+            BufferedOpenDrainKind::HostSideOutJam(Player::Player2) => OUTPUT_NAME_STRS[5],
+            BufferedOpenDrainKind::HostSideOutStart(Player::Player1) => OUTPUT_NAME_STRS[6],
+            BufferedOpenDrainKind::HostSideOutStart(Player::Player2) => OUTPUT_NAME_STRS[7],
+            BufferedOpenDrainKind::VendSideInhibit(Player::Player1) => OUTPUT_NAME_STRS[8],
+            BufferedOpenDrainKind::VendSideInhibit(Player::Player2) => OUTPUT_NAME_STRS[9],
+            BufferedOpenDrainKind::VendSideStartLed(Player::Player1) => OUTPUT_NAME_STRS[10],
+            BufferedOpenDrainKind::VendSideStartLed(Player::Player2) => OUTPUT_NAME_STRS[11],
+            BufferedOpenDrainKind::Indicator(0) => OUTPUT_NAME_STRS[12],
+            BufferedOpenDrainKind::Indicator(1) => OUTPUT_NAME_STRS[13],
+            _ => OUTPUT_NAME_STRS[14],
+        }
+    }
+}
+
+impl defmt::Format for BufferedOpenDrainKind {
+    fn format(&self, fmt: defmt::Formatter) {
+        defmt::write!(
+            fmt,
+            "{}",
+            <&Self as ConstInto<&'static str>>::const_into(self)
+        )
+    }
+}

--- a/src/types/input_port.rs
+++ b/src/types/input_port.rs
@@ -27,18 +27,35 @@ pub enum InputPortKind {
     Nothing = 10,
 }
 
+#[cfg(debug_assertions)]
 const INPUT_PORT_KIND_STRS: [&str; 11] = [
-    "Start1P",
-    "Start2P",
-    "Vend1P",
-    "Vend2P",
-    "Jam1P",
-    "Jam2P",
-    "StartJam1P",
-    "StartJam2P",
-    "Inhibit1P",
-    "Inhibit2P",
+    "VendIn_1P-Start ",
+    "VendIn_2P-Start ",
+    "VendIn_1P-Vend  ",
+    "VendIn_2P-Vend  ",
+    "VendIn_1P-Jam   ",
+    "VendIn_2P-Jam   ",
+    "VendIn_1P-STR/JAM",
+    "VendIn_2P-STR/JAM",
+    "HostIn_1P-Inhibit",
+    "HostIn_2P-Inhibit",
     "Nothing",
+];
+
+#[cfg(not(debug_assertions))]
+#[rustfmt::skip]
+const INPUT_PORT_KIND_STRS: [&str; 11] = [
+    "P1V-iSTR",
+    "P2V-iSTR",
+    "P1V-iVND",
+    "P2V-iVND",
+    "P1V-iJAM",
+    "P2V-iJAM",
+    "P1V-iS/J",
+    "P2V-iS/J",
+    "P1H-iINH",
+    "P2H-iINH",
+    "iNothing",
 ];
 
 // assert_eq!(InputPortKind::count(), INPUT_PORT_KIND_STRS.len());

--- a/src/types/input_port.rs
+++ b/src/types/input_port.rs
@@ -8,6 +8,7 @@ use num_enum::TryFromPrimitive;
 
 use crate::semi_layer::buffered_wait::{InputEventKind, RawInputEvent, RawInputPortKind};
 use crate::types::const_convert::*;
+use crate::types::player::Player;
 
 #[allow(dead_code)]
 #[repr(u8)]
@@ -29,12 +30,12 @@ pub enum InputPortKind {
 
 #[cfg(debug_assertions)]
 const INPUT_PORT_KIND_STRS: [&str; 11] = [
-    "VendIn_1P-Start ",
-    "VendIn_2P-Start ",
-    "VendIn_1P-Vend  ",
-    "VendIn_2P-Vend  ",
-    "VendIn_1P-Jam   ",
-    "VendIn_2P-Jam   ",
+    "VendIn_1P-Start  ",
+    "VendIn_2P-Start  ",
+    "VendIn_1P-Vend   ",
+    "VendIn_2P-Vend   ",
+    "VendIn_1P-Jam    ",
+    "VendIn_2P-Jam    ",
     "VendIn_1P-STR/JAM",
     "VendIn_2P-STR/JAM",
     "HostIn_1P-Inhibit",
@@ -86,6 +87,28 @@ impl const ConstFrom<InputPortKind> for RawInputPortKind {
 impl const ConstInto<RawInputPortKind> for InputPortKind {
     fn const_into(self) -> RawInputPortKind {
         RawInputPortKind::const_from(self)
+    }
+}
+
+impl InputPortKind {
+    pub const fn to_raw_and_const_str(self, player: Player) -> (RawInputPortKind, &'static str) {
+        let idx = self as u8;
+
+        // PartialEq doesn't support const boundary
+        // if Player::Undefined == player {
+        if Player::Undefined as u8 == player as u8 {
+            let ret: RawInputPortKind = self as u8;
+            return (ret, INPUT_PORT_KIND_STRS[ret as usize]);
+        } else if Self::Nothing as u8 != idx {
+            let ret = (idx + player as u8 - 1) as RawInputPortKind;
+            return (ret, INPUT_PORT_KIND_STRS[self as usize]);
+        } else {
+            (self as RawInputPortKind, self.const_str())
+        }
+    }
+
+    pub const fn const_str(self) -> &'static str {
+        INPUT_PORT_KIND_STRS[self as usize]
     }
 }
 

--- a/src/types/input_port.rs
+++ b/src/types/input_port.rs
@@ -98,10 +98,10 @@ impl InputPortKind {
         // if Player::Undefined == player {
         if Player::Undefined as u8 == player as u8 {
             let ret: RawInputPortKind = self as u8;
-            return (ret, INPUT_PORT_KIND_STRS[ret as usize]);
+            (ret, INPUT_PORT_KIND_STRS[ret as usize])
         } else if Self::Nothing as u8 != idx {
             let ret = (idx + player as u8 - 1) as RawInputPortKind;
-            return (ret, INPUT_PORT_KIND_STRS[self as usize]);
+            (ret, INPUT_PORT_KIND_STRS[self as usize])
         } else {
             (self as RawInputPortKind, self.const_str())
         }

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -11,3 +11,5 @@ pub mod input_port;
 pub mod const_convert;
 
 pub mod player;
+
+pub mod buffered_opendrain_kind;

--- a/src/types/player.rs
+++ b/src/types/player.rs
@@ -4,11 +4,24 @@
  * SPDX-License-Identifier: MIT OR Apache-2.0
  */
 
-use num_enum::TryFromPrimitive;
+use num_enum::{IntoPrimitive, TryFromPrimitive};
+
+use crate::types::const_convert::ConstInto;
 
 #[allow(dead_code)]
 #[repr(u8)]
-#[derive(Debug, defmt::Format, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, TryFromPrimitive)]
+#[derive(
+    Debug,
+    defmt::Format,
+    Clone,
+    Copy,
+    Eq,
+    PartialEq,
+    Ord,
+    PartialOrd,
+    TryFromPrimitive,
+    IntoPrimitive,
+)]
 pub enum Player {
     Undefined = 0,
     Player1 = 1,
@@ -18,5 +31,11 @@ pub enum Player {
 impl Player {
     pub const fn default() -> Self {
         Self::Undefined
+    }
+}
+
+impl ConstInto<usize> for Player {
+    fn const_into(self) -> usize {
+        self as usize
     }
 }


### PR DESCRIPTION
By using `#[cfg(debug_assertions)]`, memory usage was reduced for release build.

### Pros and characteristic about this pull request
- Enhance `BufferedOpenDrain` and `BufferedWait` debug ability.
- Better length arranged for terminal view
- Less parameter on board setup

### Cons
- release build `.text` size : 26368 -> 27092 (Diff 724 Bytes), sram : 8 bytes increased
- debug build `.text` size : 36332 -> 39036 (Diff 2704 Bytes), sram : 152 bytes increased
