### PR TITLE
Utilize busy signal and `BufferedOpenDrainRequest::OneShotHigh`

### DIFF
--- a/src/application/mod.rs
+++ b/src/application/mod.rs
@@ -24,6 +24,7 @@ use crate::types::input_port::{InputEvent, InputPortKind};
 use crate::types::player::Player;
 
 pub const DEFAULT_VEND_INDICATOR_TIMING_MS: u16 = 200;
+pub const DEFAULT_BUSY_ALPHA_TIMING_MS: u16 = 10;
 
 pub struct Application {
     /// Hardware and necessary shared object

--- a/src/application/player_to_vend_led.rs
+++ b/src/application/player_to_vend_led.rs
@@ -9,17 +9,19 @@ use crate::semi_layer::buffered_opendrain::BufferedOpenDrain;
 use crate::types::player::Player;
 
 impl Player {
-    pub const fn to_vend_and_led(
+    pub const fn to_vend_busy_led(
         self,
         board: &'static Board,
-    ) -> (&BufferedOpenDrain, &BufferedOpenDrain) {
+    ) -> (&BufferedOpenDrain, &BufferedOpenDrain, &BufferedOpenDrain) {
         match self {
             Player::Player2 => (
                 &board.hardware.host_sides[PLAYER_2_INDEX].out_vend,
+                &board.hardware.host_sides[PLAYER_2_INDEX].out_busy,
                 &board.hardware.indicators[LED_2_INDEX],
             ),
             _ => (
                 &board.hardware.host_sides[PLAYER_1_INDEX].out_vend,
+                &board.hardware.host_sides[PLAYER_2_INDEX].out_busy,
                 &board.hardware.indicators[LED_1_INDEX],
             ),
         }

--- a/src/boards/mod.rs
+++ b/src/boards/mod.rs
@@ -223,4 +223,12 @@ impl Board {
             _ => None, // this is optional action, thus return with None , not Err
         }
     }
+
+    pub fn correspond_busy(&'static self, port: &InputPortKind) -> Option<&BufferedOpenDrain> {
+        match port {
+            InputPortKind::Vend1P => Some(&self.hardware.host_sides[PLAYER_1_INDEX].out_busy),
+            InputPortKind::Vend2P => Some(&self.hardware.host_sides[PLAYER_2_INDEX].out_busy),
+            _ => None, // this is optional action, thus return with None , not Err
+        }
+    }
 }

--- a/src/semi_layer/buffered_opendrain.rs
+++ b/src/semi_layer/buffered_opendrain.rs
@@ -14,7 +14,7 @@ use embassy_time::{with_timeout, Duration, Instant, Timer};
 
 use super::timing::{SharedToggleTiming, ToggleTiming};
 
-pub const HOST_SIDE_INTERFACE_CH_SIZE: usize = 2;
+pub const HOST_SIDE_INTERFACE_CH_SIZE: usize = 4;
 pub type OpenDrainRequestChannel =
     Channel<ThreadModeRawMutex, RawBufferedOpenDrainRequest, HOST_SIDE_INTERFACE_CH_SIZE>;
 


### PR DESCRIPTION
#14 

- Add `BufferedOpenDrainRequest::OneShotHigh` on BufferedOpenDrain
- BUSY signal working as paper bill acceptor device
- Increase queue size to 4 from 2