### PR TITLE
#19 Hardware 0.4 support and 0.3/0.2 exclude host side inhibit input signal

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,11 @@ description = "application side of billmock hardware, powered by rust-embedded"
 
 [features]
 default = ["billmock_default"]
+hw_bug_host_inhibit_floating = [] # #19 bug (https://github.com/pmnxis/billmock-app-rs/issues/19)
 billmock_default = ["hw_0v3"] # To use rust-analzyer utilizing noDefaultFeatures on vscode
-hw_0v2 = []
-hw_0v3 = []
+hw_0v2 = ["hw_bug_host_inhibit_floating"]
+hw_0v3 = ["hw_bug_host_inhibit_floating"]
+hw_0v4 = []
 
 [dependencies]
 embassy-sync = { version = "0.2.0", git = "https://github.com/embassy-rs/embassy.git", rev = "c10fb7c1c4ca40749494f4873c2144906c2f1a17", features = ["defmt"] }

--- a/src/boards/billmock_0v4.rs
+++ b/src/boards/billmock_0v4.rs
@@ -1,0 +1,146 @@
+/*
+ * SPDX-FileCopyrightText: © 2023 Jinwoo Park (pmnxis@gmail.com)
+ *
+ * SPDX-License-Identifier: MIT OR Apache-2.0
+ */
+
+//! Hardware initialization code for BillMock Hardware Version 0.4
+//! The code follows on version 0.4 schematic
+//! https://github.com/pmnxis/BillMock-HW-RELEASE/blob/master/sch/BillMock-HW-0v4.pdf
+
+use embassy_stm32::exti::{Channel as HwChannel, ExtiInput};
+use embassy_stm32::gpio::{Input, Level, Output, Pin, Pull, Speed};
+use embassy_stm32::usart::{Config as UsartConfig, Uart};
+use embassy_stm32::{bind_interrupts, peripherals};
+use {defmt_rtt as _, panic_probe as _};
+
+use super::{Hardware, SharedResource};
+use super::{PLAYER_1_INDEX, PLAYER_2_INDEX};
+use crate::components;
+use crate::components::dip_switch::DipSwitch;
+use crate::components::host_side_bill::HostSideBill;
+use crate::components::serial_device::CardReaderDevice;
+use crate::components::vend_side_bill::VendSideBill;
+use crate::semi_layer::buffered_opendrain::BufferedOpenDrain;
+use crate::types::buffered_opendrain_kind::BufferedOpenDrainKind;
+use crate::types::player::Player;
+
+bind_interrupts!(struct Irqs {
+    USART2 => embassy_stm32::usart::InterruptHandler<peripherals::USART2>;
+});
+
+static mut USART2_RX_BUF: [u8; components::serial_device::CARD_READER_RX_BUFFER_SIZE] =
+    [0u8; components::serial_device::CARD_READER_RX_BUFFER_SIZE];
+
+pub fn hardware_init_0v4(
+    p: embassy_stm32::Peripherals,
+    shared_resource: &'static SharedResource,
+) -> Hardware {
+    // USART2 initialization for CardReaderDevice
+    let usart2_rx_buf = unsafe { &mut USART2_RX_BUF };
+
+    let usart2_config = {
+        let mut ret = UsartConfig::default();
+        ret.baudrate = 115200;
+        ret.assume_noise_free = false;
+        ret
+    };
+
+    let (usart2_tx, usart2_rx) = {
+        let (tx, rx) = Uart::new(
+            p.USART2,
+            p.PA3,
+            p.PA2,
+            Irqs,
+            p.DMA1_CH2,
+            p.DMA1_CH1,
+            usart2_config,
+        )
+        .split();
+        (tx, rx.into_ring_buffered(usart2_rx_buf))
+    };
+
+    let async_input_event_ch = &shared_resource.async_input_event_ch.channel;
+
+    Hardware {
+        vend_sides: [
+            VendSideBill::new(
+                Player::Player1,
+                Output::new(p.PA1.degrade(), Level::Low, Speed::Low), // REAL0_INH
+                ExtiInput::new(
+                    Input::new(p.PB2, Pull::None).degrade(), // REAL0_VND
+                    p.EXTI2.degrade(),                       // EXTI2
+                ),
+                ExtiInput::new(
+                    Input::new(p.PB14, Pull::None).degrade(), // REAL0_STR
+                    p.EXTI14.degrade(),                       // EXTI14
+                ),
+                async_input_event_ch,
+                &shared_resource.arcade_players_timing[PLAYER_1_INDEX],
+            ),
+            VendSideBill::new(
+                Player::Player2,
+                Output::new(p.PA0.degrade(), Level::Low, Speed::Low), // REAL1_INH
+                ExtiInput::new(
+                    Input::new(p.PB11, Pull::None).degrade(), // REAL1_VND
+                    p.EXTI11.degrade(),                       // EXTI11 (HW 0.2 was EXTI1 with PD1)
+                ),
+                ExtiInput::new(
+                    Input::new(p.PD1, Pull::None).degrade(), // REAL1_STR
+                    p.EXTI1.degrade(),                       // EXTI1 (HW 0.2 was EXTI11 with PB11)
+                ),
+                async_input_event_ch,
+                &shared_resource.arcade_players_timing[PLAYER_2_INDEX],
+            ),
+        ],
+        host_sides: [
+            HostSideBill::new(
+                Player::Player1,
+                ExtiInput::new(
+                    Input::new(p.PD0, Pull::None).degrade(), // VIRT0_INH
+                    p.EXTI0.degrade(),                       // EXTI0
+                ),
+                Output::new(p.PD3.degrade(), Level::Low, Speed::Low), // VIRT0_BSY
+                Output::new(p.PD2.degrade(), Level::Low, Speed::Low), // VIRT0_VND
+                Output::new(p.PB9.degrade(), Level::Low, Speed::Low), // VIRT0_JAM
+                Output::new(p.PB3.degrade(), Level::Low, Speed::Low), // VIRT0_STR
+                async_input_event_ch,
+                &shared_resource.arcade_players_timing[PLAYER_1_INDEX],
+            ),
+            HostSideBill::new(
+                Player::Player2,
+                ExtiInput::new(
+                    Input::new(p.PA15, Pull::None).degrade(), // VIRT1_INH
+                    p.EXTI15.degrade(),                       // EXTI15
+                ),
+                Output::new(p.PB4.degrade(), Level::Low, Speed::Low), // VIRT1_BSY
+                Output::new(p.PC13.degrade(), Level::Low, Speed::Low), // VIRT1_VND
+                Output::new(p.PB8.degrade(), Level::Low, Speed::Low), // VIRT1_JAM
+                Output::new(p.PB5.degrade(), Level::Low, Speed::Low), // VIRT1_STR
+                async_input_event_ch,
+                &shared_resource.arcade_players_timing[PLAYER_2_INDEX],
+            ),
+        ],
+        indicators: [
+            BufferedOpenDrain::new(
+                Output::new(p.PA4.degrade(), Level::High, Speed::Low),
+                &shared_resource.indicator_timing,
+                BufferedOpenDrainKind::Indicator(1).const_str(),
+            ),
+            BufferedOpenDrain::new(
+                Output::new(p.PA5.degrade(), Level::High, Speed::Low),
+                &shared_resource.indicator_timing,
+                BufferedOpenDrainKind::Indicator(2).const_str(),
+            ),
+        ],
+        dipsw: DipSwitch::new(
+            Input::new(p.PC6.degrade(), Pull::Up),  // DIPSW0
+            Input::new(p.PA12.degrade(), Pull::Up), // DIPSW1
+            Input::new(p.PA11.degrade(), Pull::Up), // DIPSW2
+            Input::new(p.PA9.degrade(), Pull::Up),  // DIPSW3
+            Input::new(p.PB13.degrade(), Pull::Up), // DIPSW4
+            Input::new(p.PB12.degrade(), Pull::Up), // DIPSW5
+        ),
+        card_reader: CardReaderDevice::new(usart2_tx, usart2_rx),
+    }
+}

--- a/src/boards/mod.rs
+++ b/src/boards/mod.rs
@@ -13,6 +13,8 @@ use static_cell::make_static;
 use self::billmock_0v2::hardware_init_0v2;
 #[cfg(feature = "hw_0v3")]
 use self::billmock_0v3::hardware_init_0v3;
+#[cfg(feature = "hw_0v4")]
+use self::billmock_0v4::hardware_init_0v4;
 use crate::components::dip_switch::DipSwitch;
 use crate::components::host_side_bill::HostSideBill;
 use crate::components::serial_device::{self, card_reader_device_spawn, CardReaderDevice};
@@ -40,6 +42,8 @@ const PRINT_BAR: &str = "+------------------------------------------------------
 mod billmock_0v2;
 #[cfg(feature = "hw_0v3")]
 mod billmock_0v3;
+#[cfg(feature = "hw_0v4")]
+mod billmock_0v4;
 
 pub struct Hardware {
     /// Bill paper and coin acceptor input device for 1 and 2 player sides
@@ -100,11 +104,17 @@ impl Hardware {
         peripherals: embassy_stm32::Peripherals,
         shared_resource: &'static SharedResource,
     ) -> Hardware {
-        #[cfg(feature = "hw_0v2")]
+        #[cfg(all(feature = "hw_0v2", not(feature = "hw_0v3"), not(feature = "hw_0v4")))]
         let ret = hardware_init_0v2(peripherals, shared_resource);
 
-        #[cfg(feature = "hw_0v3")]
+        #[cfg(any(
+            all(feature = "hw_0v3", not(feature = "hw_0v2"), not(feature = "hw_0v4")),
+            feature = "billmock_default"
+        ))]
         let ret = hardware_init_0v3(peripherals, shared_resource);
+
+        #[cfg(all(feature = "hw_0v4", not(feature = "hw_0v2"), not(feature = "hw_0v3")))]
+        let ret = hardware_init_0v4(peripherals, shared_resource);
 
         ret
     }

--- a/src/components/host_side_bill.rs
+++ b/src/components/host_side_bill.rs
@@ -10,6 +10,7 @@ use embassy_stm32::exti::ExtiInput;
 use embassy_stm32::gpio::{AnyPin, Output};
 
 use crate::semi_layer::buffered_opendrain::{buffered_opendrain_spawn, BufferedOpenDrain};
+#[cfg(not(feature = "hw_bug_host_inhibit_floating"))]
 use crate::semi_layer::buffered_wait::buffered_wait_spawn;
 use crate::semi_layer::buffered_wait::{BufferedWait, InputEventChannel, RawInputPortKind};
 use crate::semi_layer::timing::SharedToggleTiming;
@@ -18,6 +19,7 @@ use crate::types::input_port::InputPortKind;
 use crate::types::player::Player;
 
 pub struct HostSideBill {
+    #[cfg_attr(feature = "hw_bug_host_inhibit_floating", allow(unused))]
     in_inhibit: BufferedWait,
     pub out_busy: BufferedOpenDrain,
     pub out_vend: BufferedOpenDrain,
@@ -66,6 +68,8 @@ impl HostSideBill {
         unwrap!(spawner.spawn(buffered_opendrain_spawn(&self.out_vend)));
         unwrap!(spawner.spawn(buffered_opendrain_spawn(&self.out_jam)));
         unwrap!(spawner.spawn(buffered_opendrain_spawn(&self.out_start)));
+
+        #[cfg(not(feature = "hw_bug_host_inhibit_floating"))]
         unwrap!(spawner.spawn(buffered_wait_spawn(&self.in_inhibit)));
     }
 }


### PR DESCRIPTION
Consider command `cargo clippy --all-features -- -Dclippy::all` , cfg_attr is fixed.

#19 