### PR TITLE
[HOTFIX] Pre constly defined NovellaSelctor for each enums

### DIFF
--- a/src/components/eeprom.rs
+++ b/src/components/eeprom.rs
@@ -148,6 +148,45 @@ pub struct NovellaSelector<T> {
     pub marker: PhantomData<T>, // 0-byte guarantees
 }
 
+#[allow(unused)]
+pub mod select {
+    use super::*;
+    use crate::types::fault_log::FaultLog;
+
+    pub const P1_CARD_CNT: NovellaSelector<u32> = NovellaSelector {
+        section: NvMemSectionKind::P1CardCnt,
+        marker: core::marker::PhantomData,
+    };
+    pub const P2_CARD_CNT: NovellaSelector<u32> = NovellaSelector {
+        section: NvMemSectionKind::P2CardCnt,
+        marker: core::marker::PhantomData,
+    };
+    pub const P1_COIN_CNT: NovellaSelector<u32> = NovellaSelector {
+        section: NvMemSectionKind::P1CoinCnt,
+        marker: core::marker::PhantomData,
+    };
+    pub const P2_COIN_CNT: NovellaSelector<u32> = NovellaSelector {
+        section: NvMemSectionKind::P2CoinCnt,
+        marker: core::marker::PhantomData,
+    };
+    pub const FAULT_LOG: NovellaSelector<FaultLog> = NovellaSelector {
+        section: NvMemSectionKind::FaultLog,
+        marker: core::marker::PhantomData,
+    };
+    pub const HW_BOOT_CNT: NovellaSelector<u32> = NovellaSelector {
+        section: NvMemSectionKind::HwBootCount,
+        marker: core::marker::PhantomData,
+    };
+    pub const TERMINAL_ID: NovellaSelector<RawTerminalId> = NovellaSelector {
+        section: NvMemSectionKind::TerminalId,
+        marker: core::marker::PhantomData,
+    };
+    pub const CARD_PORT_BACKUP: NovellaSelector<CardReaderPortBackup> = NovellaSelector {
+        section: NvMemSectionKind::CardPortBackup,
+        marker: core::marker::PhantomData,
+    };
+}
+
 // #[async_trait]
 pub trait NovellaRw {
     type InnerType: Sized;

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,7 +24,7 @@ use {defmt_rtt as _, panic_probe as _};
 
 use crate::application::Application;
 use crate::boards::*;
-use crate::components::eeprom::{NovellaSelector, NvMemSectionKind};
+use crate::components::eeprom::select;
 
 #[embassy_executor::main]
 async fn main(spawner: Spawner) {
@@ -51,15 +51,9 @@ async fn main(spawner: Spawner) {
         }
     };
 
-    // NovellaSelector<u32> { section: NvMemSectionKind::HwBootCount},
-
-    let boot_cnt_sel: NovellaSelector<u32> = NovellaSelector {
-        section: NvMemSectionKind::HwBootCount,
-        marker: core::marker::PhantomData,
-    };
-    let boot_cnt = eeprom.lock_read::<NovellaSelector<u32>>(boot_cnt_sel).await;
-    eeprom.lock_write(boot_cnt_sel, boot_cnt + 1).await;
-    let boot_cnt_after = eeprom.lock_read::<NovellaSelector<u32>>(boot_cnt_sel).await;
+    let boot_cnt = eeprom.lock_read(select::HW_BOOT_CNT).await;
+    eeprom.lock_write(select::HW_BOOT_CNT, boot_cnt + 1).await;
+    let boot_cnt_after = eeprom.lock_read(select::HW_BOOT_CNT).await;
     let uptime = eeprom.get_uptime().await;
     let uptime_secs = uptime.as_secs();
 


### PR DESCRIPTION
After works of #22 and #28.

Previous code need to make anon NovellaSelector struct for using Read/Write eeprom data.
In this PR, by predefined NovellaSelectors for each element, avoid annoy codes.