### PR TITLE
#33 Use OTP MCU features and `billmock-mptool`

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -23,7 +23,8 @@
   "rust-analyzer.cargo.target": "thumbv6m-none-eabi",
   "rust-analyzer.linkedProjects": [
     "Cargo.toml",
+    "billmock-mptool/Cargo.toml",
     "billmock-plug-card/Cargo.toml",
-    "card-terminal-adapter/Cargo.toml",
+    "card-terminal-adapter/Cargo.toml"
   ],
 }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,9 +53,9 @@ env_to_array = { version = "0.3.1", features = ["hex"] }
 # `billmock-plug-card` would be replaced to NDA library that working on real field with dependency injection
 # details : https://doc.rust-lang.org/cargo/reference/overriding-dependencies.html#the-patch-section
 
-# uncoment later
 card-terminal-adapter = { git = "https://github.com/pmnxis/billmock-app-rs.git" }
 billmock-plug-card = { git = "https://github.com/pmnxis/billmock-app-rs.git" }
+billmock-otp-dev-info = { git = "https://github.com/pmnxis/billmock-mptool.git" }
 
 [build-dependencies]
 git2 = "0.18" # Git library for Rust

--- a/src/boards/const_str.rs
+++ b/src/boards/const_str.rs
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: MIT OR Apache-2.0
  */
 
+use billmock_otp_dev_info::OtpDeviceInfo;
 use env_to_array::hex_env_to_array;
 
 pub const PROJECT_NAME: &str = env!("PROJECT_NAME");
@@ -16,7 +17,16 @@ pub const COMMIT_HASH: &str = env!("GIT_COMMIT_HASH");
 pub(crate) const COMMIT_SHORT: [u8; card_terminal_adapter::GIT_HASH_LEN] =
     hex_env_to_array!("GIT_COMMIT_SHORT_HASH");
 
-pub const SERIAL_NUMBER_WHEN_UNKNOWN: [u8; card_terminal_adapter::DEV_SN_LEN] = *b"    90000000";
+pub const SERIAL_NUMBER_WHEN_UNKNOWN: [u8; card_terminal_adapter::DEV_SN_LEN] = *b"     unknown";
 
 pub const GIT_COMMIT_DATETIME: &str = env!("GIT_COMMIT_DATETIME");
 pub const PRINT_BAR: &str = "+-----------------------------------------------------------+";
+
+pub fn get_serial_number() -> &'static [u8; card_terminal_adapter::DEV_SN_LEN] {
+    let otp_space = OtpDeviceInfo::from_stm32g0();
+
+    match otp_space.check_and_sn() {
+        Err(_) => &SERIAL_NUMBER_WHEN_UNKNOWN,
+        Ok(_) => &otp_space.dev_sn,
+    }
+}

--- a/src/boards/mod.rs
+++ b/src/boards/mod.rs
@@ -223,6 +223,7 @@ impl Board {
         defmt::println!("{}", const_str::PRINT_BAR);
         #[rustfmt::skip]
         defmt::println!("Firmware Ver : {} {=[u8]:a}", const_str::PROJECT_NAME, const_str::VERSION_STR);
+        defmt::println!("SerialNumber : {=[u8]:a}", *const_str::get_serial_number());
         defmt::println!("Git Hash     : {}", const_str::COMMIT_HASH);
         #[rustfmt::skip]
         defmt::println!("Git Datetime : {} | {=[u8]:a}", const_str::GIT_COMMIT_DATETIME, const_str::COMMIT_SHORT);

--- a/src/components/serial_device.rs
+++ b/src/components/serial_device.rs
@@ -76,7 +76,7 @@ impl CardReaderDevice {
                         CardTerminalTxCmd::ResponseDeviceInfo => plug.response_device_info(
                             &mut tx_buf,
                             &const_str::VERSION_STR,
-                            &const_str::SERIAL_NUMBER_WHEN_UNKNOWN, // todo! - get last MCU flash page for getting serial number
+                            const_str::get_serial_number(),
                         ),
                         CardTerminalTxCmd::PushCoinPaperAcceptorIncome(x) => {
                             plug.alert_coin_paper_acceptor_income(&mut tx_buf, x)


### PR DESCRIPTION
### Original Ticket 
#33 

### Description
<img width="816" alt="스크린샷 2023-10-22 23 52 58" src="https://github.com/pmnxis/billmock-app-rs/assets/7401129/8a516fe5-c2ff-4d11-8a53-c01ff85b7f40">

Utilized [billmock-mptool](https://github.com/pmnxis/billmock-mptool) to use OPT (One Time Programmable) memory.

Also mptool unlock or lock RDP (Read Protection) of MCU and read or write OPT data.
