### PR TITLE
#38 0v5 mini hardware support and minor bugs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,14 +12,15 @@ description = "application side of billmock hardware, powered by rust-embedded"
 
 [features]
 default = ["billmock_default"]
-hw_bug_host_inhibit_floating = [] # #19 bug (https://github.com/pmnxis/billmock-app-rs/issues/19)
+hw_bug_host_inhibit_floating = []  # #19 bug (https://github.com/pmnxis/billmock-app-rs/issues/19)
 billmock_default = ["hw_mini_0v5"] # To use rust-analzyer utilizing noDefaultFeatures on vscode
 eeprom = []
+svc_button = []                    # SVC button
 hw_0v2 = ["hw_bug_host_inhibit_floating"]
 hw_0v3 = ["hw_bug_host_inhibit_floating"]
 hw_0v4 = ["eeprom"]
 hw_mini_0v4 = ["eeprom"]
-hw_mini_0v5 = ["eeprom"]
+hw_mini_0v5 = ["eeprom", "svc_button"]
 
 [dependencies]
 embassy-sync = { version = "0.3.0", git = "https://github.com/embassy-rs/embassy.git", rev = "b6fc682117a41e8e63a9632e06da5a17f46d9ab0", features = ["defmt"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,12 +13,13 @@ description = "application side of billmock hardware, powered by rust-embedded"
 [features]
 default = ["billmock_default"]
 hw_bug_host_inhibit_floating = [] # #19 bug (https://github.com/pmnxis/billmock-app-rs/issues/19)
-billmock_default = ["hw_mini_0v4"] # To use rust-analzyer utilizing noDefaultFeatures on vscode
+billmock_default = ["hw_mini_0v5"] # To use rust-analzyer utilizing noDefaultFeatures on vscode
 eeprom = []
 hw_0v2 = ["hw_bug_host_inhibit_floating"]
 hw_0v3 = ["hw_bug_host_inhibit_floating"]
 hw_0v4 = ["eeprom"]
 hw_mini_0v4 = ["eeprom"]
+hw_mini_0v5 = ["eeprom"]
 
 [dependencies]
 embassy-sync = { version = "0.3.0", git = "https://github.com/embassy-rs/embassy.git", rev = "b6fc682117a41e8e63a9632e06da5a17f46d9ab0", features = ["defmt"] }

--- a/README.md
+++ b/README.md
@@ -24,14 +24,19 @@ This project began development at the request of **GPARK Co., Ltd**<sup>[4](#foo
 The project has been granted an open source disclosure except of NDA era.
 
 ## Target Hardware
-Based on BillMock-HW 0.4 mini and 0.4. <br/>
+Based on BillMock-HW 0.5 mini, 0.4 mini and 0.4. <br/>
 0.2 and 0.3 HW bring-up codes are still left for recyle the old PCB.
 - 0.2 HW has different gpio configuration compare to latest boards.
 - 0.3 HW has minor bugs, floating on VendSide-Inhibit and missing net route on VendSide-1P-StartJam.
 - 0.4 HW fixed 0.3 HW bugs.
 - 0.4 HW mini reduced BOM for mass-manufacturing
+- 0.5 HW mini added tact switch for SVC mode call
 
-If need to use old 0.2 HW, run `cargo build --features hw_0v2 --no-default-features`.
+Current default HW is `0.5 mini`. If need to use old 0.4 or 0.4 mini, following below command lines
+```sh
+cargo build --features hw_0v4 --no-default-features --release
+cargo build --features hw_mini_0v4 --no-default-features --release
+```
 
 ### Target hardware image
 ![Actual BillMock PCB 0v3](https://billmock.gpark.biz/images/BillMockPCB_0v4.jpg)
@@ -42,8 +47,11 @@ https://github.com/pmnxis/BillMock-HW-RELEASE
 
 The schematic printed in PDF is distributed under CC BY-SA 3.0, but the actual Gerber files and project files are private.
 
+#### v 0.5 Mini (2023-10-24)
+[BillMock-Mini-HW-0v5.pdf](https://github.com/pmnxis/BillMock-HW-RELEASE/blob/master/sch/BillMock-Mini-HW-0v5.pdf)
+
 #### v 0.4 Mini (2023-09-12 or 2023-09-13)
-[BillMock-Mini-HW-0v4.pdf](https://github.com/pmnxis/BillMock-HW-RELEASE/blob/master/sch//BillMock-Mini-HW-0v4.pdf)
+[BillMock-Mini-HW-0v4.pdf](https://github.com/pmnxis/BillMock-HW-RELEASE/blob/master/sch/BillMock-Mini-HW-0v4.pdf)
 
 #### v 0.4 (2023-09-08)
 [BillMock-HW-0v4.pdf](https://github.com/pmnxis/BillMock-HW-RELEASE/blob/master/sch/BillMock-HW-0v4.pdf)

--- a/book/src/port_04_mini_host_side.md
+++ b/book/src/port_04_mini_host_side.md
@@ -30,7 +30,7 @@ SPDX-License-Identifier: MIT OR Apache-2.0
 | `10`      | `GND`          | Product - Pole Power Input                             |
 
 
-- Pins are counted from the left.
+- Pins are counted from the right.
 - You can also input power directly into BillMock-HW through `12V` and `GND` pins.
 - The power pins from this port cannot be used for power output. When power input to this port is blocked, reverse voltage does not flow.
 - The "Busy" output signal remains active low from the moment a payment signal is received from the credit card or when the VEND input signal goes active low until the VEND output signal toggles and completes.
@@ -60,7 +60,7 @@ SPDX-License-Identifier: MIT OR Apache-2.0
 | `9`       | `12V`          | Product + Pole Power Input                             |
 | `10`      | `GND`          | Product - Pole Power Input                             |
 
-- Pins are counted from the left.
+- Pins are counted from the right.
 - You can also input power directly into BillMock-HW through `12V` and `GND` pins.
 - The power pins from this port cannot be used for power output. When power input to this port is blocked, reverse voltage does not flow.
 - The "Busy" output signal remains active low from the moment a payment signal is received from the credit card or when the VEND input signal goes active low until the VEND output signal toggles and completes.

--- a/src/application/io_bypass.rs
+++ b/src/application/io_bypass.rs
@@ -14,11 +14,15 @@ use crate::types::input_port::{InputEvent, InputPortKind};
 pub async fn io_bypass(board: &'static Board, event: &InputEvent, override_druation_force: bool) {
     let output = match board.correspond_output(&event.port) {
         Ok(x) => x,
+        #[cfg(feature = "svc_button")]
+        Err(BoardCorrespondOutputMatchError {
+            origin: InputPortKind::SvcButton,
+        }) => {
+            // Svc Button is not output type
+            return;
+        }
         Err(e) => {
-            error!(
-                "io_bypass some wrong enum value income : 0x{:02X}",
-                e.origin
-            );
+            error!("io_bypass some wrong enum value income : {}", e.origin);
             return;
         }
     };

--- a/src/application/io_remap.rs
+++ b/src/application/io_remap.rs
@@ -99,6 +99,7 @@ impl InputEvent {
                 InputPortKind::StartJam2P => InputPortKind::StartJam1P,
                 InputPortKind::Vend2P => InputPortKind::Vend1P,
                 InputPortKind::Vend1P => InputPortKind::Vend2P,
+                InputPortKind::SvcButton => InputPortKind::SvcButton,
                 InputPortKind::Nothing => InputPortKind::Nothing,
             },
             event: self.event,

--- a/src/application/mod.rs
+++ b/src/application/mod.rs
@@ -199,6 +199,30 @@ impl Application {
                 // defmt::info!("Input cache state changed : {:04X}", input_bits);
 
                 match InputEvent::try_from(raw_input_event) {
+                    #[cfg(feature = "svc_button")]
+                    Ok(InputEvent {
+                        port: InputPortKind::SvcButton,
+                        event: InputEventKind::LongPressed(t),
+                    }) => {
+                        if (2 < t) && (t < 120) {
+                            hardware
+                                .card_reader
+                                .send(CardTerminalTxCmd::DisplayRom)
+                                .await;
+                        } else {
+                            hardware
+                                .card_reader
+                                .send(CardTerminalTxCmd::DisplayHwInfo)
+                                .await;
+                        }
+
+                        yield_now().await;
+                        // Some(InputEvent {
+                        //     port: InputPortKind::SvcButton,
+                        //     event: InputEventKind::LongPressed(t),
+                        // })
+                        None
+                    }
                     Ok(y) => {
                         let ret = y
                             .replace_arr(match appmode {

--- a/src/application/mod.rs
+++ b/src/application/mod.rs
@@ -50,7 +50,7 @@ impl Application {
         let mut default_serial = Player::Undefined;
         let mut income_backup: Option<PaymentReceive> = None; // for StartButtonDecideSerialToVend
         let mut mutual_inhibit = MutualInhibit::new();
-        let mut did_we_ask = false;
+        let mut did_we_ask: u8 = 0;
 
         loop {
             // timing flag would be used in future implementation.
@@ -115,14 +115,14 @@ impl Application {
                             .send(CardTerminalTxCmd::ResponseDeviceInfo)
                             .await;
 
-                        if !did_we_ask {
-                            did_we_ask = true;
-
+                        if (did_we_ask & 0b111) == 0 {
                             hardware
                                 .card_reader
                                 .send(CardTerminalTxCmd::RequestTerminalInfo)
                                 .await;
                         }
+
+                        did_we_ask += 1;
                     }
                     CardTerminalRxCmd::AlertPaymentIncomeArcade(raw_income) => {
                         // judge current application mode and income backup

--- a/src/boards/billmock_mini_0v5.rs
+++ b/src/boards/billmock_mini_0v5.rs
@@ -1,0 +1,176 @@
+/*
+ * SPDX-FileCopyrightText: © 2023 Jinwoo Park (pmnxis@gmail.com)
+ *
+ * SPDX-License-Identifier: MIT OR Apache-2.0
+ */
+
+//! Hardware initialization code for BillMock Hardware Version mini 0.4
+//! The code follows on version mini 0.4 schematic
+//! https://github.com/pmnxis/BillMock-HW-RELEASE/blob/master/sch/BillMock-Mini-HW-0v5.pdf
+
+use embassy_stm32::crc::{Config as CrcConfig, Crc, InputReverseConfig};
+use embassy_stm32::exti::{Channel as HwChannel, ExtiInput};
+use embassy_stm32::gpio::{Input, Level, Output, Pin, Pull, Speed};
+use embassy_stm32::i2c::I2c;
+use embassy_stm32::time::Hertz;
+use embassy_stm32::usart::{Config as UsartConfig, Uart};
+use embassy_stm32::{bind_interrupts, peripherals};
+use {defmt_rtt as _, panic_probe as _};
+
+use super::{Hardware, SharedResource};
+use super::{PLAYER_1_INDEX, PLAYER_2_INDEX};
+use crate::components;
+use crate::components::dip_switch::DipSwitch;
+use crate::components::eeprom::Novella;
+use crate::components::host_side_bill::HostSideBill;
+use crate::components::serial_device::CardReaderDevice;
+use crate::components::vend_side_bill::VendSideBill;
+use crate::semi_layer::buffered_opendrain::BufferedOpenDrain;
+use crate::types::buffered_opendrain_kind::BufferedOpenDrainKind;
+use crate::types::player::Player;
+
+bind_interrupts!(struct Irqs {
+    USART2 => embassy_stm32::usart::InterruptHandler<peripherals::USART2>;
+    I2C1 => embassy_stm32::i2c::InterruptHandler<peripherals::I2C1>;
+});
+
+static mut USART2_RX_BUF: [u8; components::serial_device::CARD_READER_RX_BUFFER_SIZE] =
+    [0u8; components::serial_device::CARD_READER_RX_BUFFER_SIZE];
+
+pub fn hardware_init_mini_0v5(
+    p: embassy_stm32::Peripherals,
+    shared_resource: &'static SharedResource,
+) -> Hardware {
+    // USART2 initialization for CardReaderDevice
+    let usart2_rx_buf = unsafe { &mut USART2_RX_BUF };
+
+    let usart2_config = {
+        let mut ret: UsartConfig = UsartConfig::default();
+        ret.baudrate = 115200;
+        ret.assume_noise_free = false;
+        ret.detect_previous_overrun = true;
+        ret
+    };
+
+    let (usart2_tx, usart2_rx) = {
+        let (tx, rx) = Uart::new(
+            p.USART2,
+            p.PA3,
+            p.PA2,
+            Irqs,
+            p.DMA1_CH2,
+            p.DMA1_CH1,
+            usart2_config,
+        )
+        .unwrap()
+        .split();
+        (tx, rx.into_ring_buffered(usart2_rx_buf))
+    };
+
+    let i2c = I2c::new(
+        p.I2C1,
+        p.PB8,
+        p.PB9,
+        Irqs,
+        p.DMA1_CH4,
+        p.DMA1_CH3,
+        Hertz(400_000),
+        Default::default(),
+    );
+
+    // InputReverseConfig::Halfword
+    let Ok(crc_config) = CrcConfig::new(InputReverseConfig::Word, false, 0xA097) else {
+        panic!("Something went horribly wrong")
+    };
+
+    let crc = Crc::new(p.CRC, crc_config);
+
+    let async_input_event_ch = &shared_resource.async_input_event_ch.channel;
+
+    Hardware {
+        vend_sides: [
+            VendSideBill::new(
+                Player::Player1,
+                Output::new(p.PA1.degrade(), Level::Low, Speed::Low), // REAL0_INH
+                ExtiInput::new(
+                    Input::new(p.PB14, Pull::None).degrade(), // REAL0_VND
+                    p.EXTI14.degrade(),                       // EXTI14
+                ),
+                ExtiInput::new(
+                    Input::new(p.PB2, Pull::None).degrade(), // REAL0_STR
+                    p.EXTI2.degrade(),                       // EXTI2
+                ),
+                async_input_event_ch,
+                &shared_resource.arcade_players_timing[PLAYER_1_INDEX],
+            ),
+            VendSideBill::new(
+                Player::Player2,
+                Output::new(p.PA0.degrade(), Level::Low, Speed::Low), // REAL1_INH
+                ExtiInput::new(
+                    Input::new(p.PD1, Pull::None).degrade(), // REAL1_VND
+                    p.EXTI1.degrade(),                       // EXTI1
+                ),
+                ExtiInput::new(
+                    Input::new(p.PB11, Pull::None).degrade(), // REAL1_STR
+                    p.EXTI11.degrade(),                       // EXTI11
+                ),
+                async_input_event_ch,
+                &shared_resource.arcade_players_timing[PLAYER_2_INDEX],
+            ),
+        ],
+        host_sides: [
+            HostSideBill::new(
+                Player::Player1,
+                ExtiInput::new(
+                    Input::new(p.PD0, Pull::None).degrade(), // VIRT0_INH
+                    p.EXTI0.degrade(),                       // EXTI0
+                ),
+                Output::new(p.PD3.degrade(), Level::Low, Speed::Low), // VIRT0_BSY
+                Output::new(p.PD2.degrade(), Level::Low, Speed::Low), // VIRT0_VND
+                Output::new(p.PB4.degrade(), Level::Low, Speed::Low), // VIRT0_JAM
+                Output::new(p.PB3.degrade(), Level::Low, Speed::Low), // VIRT0_STR
+                async_input_event_ch,
+                &shared_resource.arcade_players_timing[PLAYER_1_INDEX],
+            ),
+            HostSideBill::new(
+                Player::Player2,
+                ExtiInput::new(
+                    Input::new(p.PA15, Pull::None).degrade(), // VIRT1_INH
+                    p.EXTI15.degrade(),                       // EXTI15
+                ),
+                Output::new(p.PC14.degrade(), Level::Low, Speed::Low), // VIRT1_BSY
+                Output::new(p.PC13.degrade(), Level::Low, Speed::Low), // VIRT1_VND
+                Output::new(p.PB5.degrade(), Level::Low, Speed::Low),  // VIRT1_JAM
+                Output::new(p.PC15.degrade(), Level::Low, Speed::Low), // VIRT1_STR
+                async_input_event_ch,
+                &shared_resource.arcade_players_timing[PLAYER_2_INDEX],
+            ),
+        ],
+        indicators: [
+            BufferedOpenDrain::new(
+                Output::new(p.PA5.degrade(), Level::High, Speed::Low),
+                &shared_resource.indicator_timing,
+                BufferedOpenDrainKind::Indicator(1).const_str(),
+            ),
+            BufferedOpenDrain::new(
+                Output::new(p.PA4.degrade(), Level::High, Speed::Low),
+                &shared_resource.indicator_timing,
+                BufferedOpenDrainKind::Indicator(2).const_str(),
+            ),
+        ],
+        dipsw: DipSwitch::new(
+            Input::new(p.PC6.degrade(), Pull::Up),  // DIPSW0
+            Input::new(p.PA12.degrade(), Pull::Up), // DIPSW1
+            Input::new(p.PA11.degrade(), Pull::Up), // DIPSW2
+            Input::new(p.PA9.degrade(), Pull::Up),  // DIPSW3
+            Input::new(p.PB13.degrade(), Pull::Up), // DIPSW4
+            Input::new(p.PB12.degrade(), Pull::Up), // DIPSW5
+        ),
+        card_reader: CardReaderDevice::new(usart2_tx, usart2_rx),
+        eeprom: Novella::const_new(
+            i2c,
+            crc,
+            embassy_stm32::gpio::OutputOpenDrain::new(p.PF0, Level::Low, Speed::Low, Pull::None),
+        ),
+    }
+}

--- a/src/boards/mod.rs
+++ b/src/boards/mod.rs
@@ -26,6 +26,8 @@ use crate::components::host_side_bill::HostSideBill;
 use crate::components::serial_device::{self, card_reader_device_spawn, CardReaderDevice};
 use crate::components::vend_side_bill::VendSideBill;
 use crate::semi_layer::buffered_opendrain::{buffered_opendrain_spawn, BufferedOpenDrain};
+#[cfg(feature = "svc_button")]
+use crate::semi_layer::buffered_wait::{buffered_wait_spawn, BufferedWait};
 use crate::semi_layer::buffered_wait_receiver::BufferedWaitReceiver;
 use crate::semi_layer::timing::{SharedToggleTiming, ToggleTiming};
 use crate::types::input_port::InputPortKind;
@@ -69,6 +71,10 @@ pub struct Hardware {
 
     /// Eeprom manager, powered by Novella
     pub eeprom: Novella,
+
+    #[cfg(feature = "svc_button")]
+    /// SVC button (tactile switch) for engineer or foreman
+    pub svc_button: BufferedWait,
 }
 
 impl Hardware {
@@ -181,6 +187,10 @@ impl Hardware {
         // LED indicators inside of PCB initialization. for debug / indication.
         unwrap!(spawner.spawn(buffered_opendrain_spawn(&self.indicators[LED_1_INDEX])));
         unwrap!(spawner.spawn(buffered_opendrain_spawn(&self.indicators[LED_2_INDEX])));
+
+        #[cfg(feature = "svc_button")]
+        // SVC button (tact button) insde of PCB. for engineer and foreman
+        unwrap!(spawner.spawn(buffered_wait_spawn(&self.svc_button)));
 
         unwrap!(spawner.spawn(novella_spawn(&self.eeprom)));
 

--- a/src/boards/mod.rs
+++ b/src/boards/mod.rs
@@ -17,6 +17,8 @@ use self::billmock_0v3::hardware_init_0v3;
 use self::billmock_0v4::hardware_init_0v4;
 #[cfg(feature = "hw_mini_0v4")]
 use self::billmock_mini_0v4::hardware_init_mini_0v4;
+#[cfg(feature = "hw_mini_0v5")]
+use self::billmock_mini_0v5::hardware_init_mini_0v5;
 use crate::components::dip_switch::DipSwitch;
 use crate::components::eeprom::novella_spawn;
 use crate::components::eeprom::Novella;
@@ -46,6 +48,8 @@ mod billmock_0v3;
 mod billmock_0v4;
 #[cfg(feature = "hw_mini_0v4")]
 mod billmock_mini_0v4;
+#[cfg(feature = "hw_mini_0v5")]
+mod billmock_mini_0v5;
 
 pub struct Hardware {
     /// Bill paper and coin acceptor input device for 1 and 2 player sides
@@ -113,7 +117,8 @@ impl Hardware {
             feature = "hw_0v2",
             not(feature = "hw_0v3"),
             not(feature = "hw_0v4"),
-            not(feature = "hw_mini_0v4")
+            not(feature = "hw_mini_0v4"),
+            not(feature = "hw_mini_0v5")
         ))]
         let ret = hardware_init_0v2(peripherals, shared_resource);
 
@@ -122,7 +127,8 @@ impl Hardware {
                 feature = "hw_0v3",
                 not(feature = "hw_0v2"),
                 not(feature = "hw_0v4"),
-                not(feature = "hw_mini_0v4")
+                not(feature = "hw_mini_0v4"),
+                not(feature = "hw_mini_0v5")
             ),
             feature = "billmock_default"
         ))]
@@ -132,7 +138,8 @@ impl Hardware {
             feature = "hw_0v4",
             not(feature = "hw_0v2"),
             not(feature = "hw_0v3"),
-            not(feature = "hw_mini_0v4")
+            not(feature = "hw_mini_0v4"),
+            not(feature = "hw_mini_0v5")
         ))]
         let ret = hardware_init_0v4(peripherals, shared_resource);
 
@@ -140,9 +147,19 @@ impl Hardware {
             feature = "hw_mini_0v4",
             not(feature = "hw_0v2"),
             not(feature = "hw_0v3"),
-            not(feature = "hw_0v4")
+            not(feature = "hw_0v4"),
+            not(feature = "hw_mini_0v5")
         ))]
         let ret = hardware_init_mini_0v4(peripherals, shared_resource);
+
+        #[cfg(all(
+            feature = "hw_mini_0v5",
+            not(feature = "hw_0v2"),
+            not(feature = "hw_0v3"),
+            not(feature = "hw_0v4"),
+            not(feature = "hw_mini_0v4")
+        ))]
+        let ret = hardware_init_mini_0v5(peripherals, shared_resource);
 
         ret
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,7 +52,7 @@ async fn initial_eeprom(eeprom: &crate::components::eeprom::Novella) {
     let boot_cnt = eeprom.lock_read(select::HW_BOOT_CNT).await;
     eeprom.lock_write(select::HW_BOOT_CNT, boot_cnt + 1).await;
     let boot_cnt_after = eeprom.lock_read(select::HW_BOOT_CNT).await;
-    let uptime = eeprom.get_uptime().await;
+    let uptime = eeprom.get_uptime();
     let uptime_secs = uptime.as_secs();
 
     defmt::info!("Boot Count : {} -> {}", boot_cnt, boot_cnt_after,);
@@ -72,7 +72,6 @@ async fn main(spawner: Spawner) {
     let board: &'static mut Board = make_static!(Board::init());
 
     // init hardware eeprom
-
     // Count up boot count and show uptime though DAP.
     initial_eeprom(&board.hardware.eeprom).await;
 

--- a/src/semi_layer/buffered_wait.rs
+++ b/src/semi_layer/buffered_wait.rs
@@ -150,10 +150,18 @@ impl BufferedWait {
     }
 }
 
-// in HW v0.2 pool usage would be 6.
-// PCB use 6 EXTI
+// in HW v0.4 pool usage would be 6.
 // single task pool consume 88 bytes
+#[cfg(not(feature = "svc_button"))]
 #[embassy_executor::task(pool_size = 6)]
+pub async fn buffered_wait_spawn(instance: &'static BufferedWait) {
+    instance.run().await
+}
+
+// in HW v0.5 pool usage would be 7. (+ SVC_Button)
+// single task pool consume 88 bytes
+#[cfg(feature = "svc_button")]
+#[embassy_executor::task(pool_size = 7)]
 pub async fn buffered_wait_spawn(instance: &'static BufferedWait) {
     instance.run().await
 }

--- a/src/types/input_port.rs
+++ b/src/types/input_port.rs
@@ -24,12 +24,13 @@ pub enum InputPortKind {
     StartJam2P = 7,
     Inhibit1P = 8,
     Inhibit2P = 9,
+    SvcButton = 10,
     // Ignored signal by filter function
-    Nothing = 10,
+    Nothing = 11,
 }
 
 #[cfg(debug_assertions)]
-const INPUT_PORT_KIND_STRS: [&str; 11] = [
+const INPUT_PORT_KIND_STRS: [&str; 12] = [
     "VendIn_1P-Start  ",
     "VendIn_2P-Start  ",
     "VendIn_1P-Vend   ",
@@ -40,12 +41,13 @@ const INPUT_PORT_KIND_STRS: [&str; 11] = [
     "VendIn_2P-STR/JAM",
     "HostIn_1P-Inhibit",
     "HostIn_2P-Inhibit",
+    "SVC_Button       ",
     "Nothing",
 ];
 
 #[cfg(not(debug_assertions))]
 #[rustfmt::skip]
-const INPUT_PORT_KIND_STRS: [&str; 11] = [
+const INPUT_PORT_KIND_STRS: [&str; 12] = [
     "P1V-iSTR",
     "P2V-iSTR",
     "P1V-iVND",
@@ -56,6 +58,7 @@ const INPUT_PORT_KIND_STRS: [&str; 11] = [
     "P2V-iS/J",
     "P1H-iINH",
     "P2H-iINH",
+    "iSVC_BT ",
     "iNothing",
 ];
 
@@ -96,7 +99,7 @@ impl InputPortKind {
 
         // PartialEq doesn't support const boundary
         // if Player::Undefined == player {
-        if Player::Undefined as u8 == player as u8 {
+        if (Player::Undefined as u8 == player as u8) || (idx == Self::SvcButton as u8) {
             let ret: RawInputPortKind = self as u8;
             (ret, INPUT_PORT_KIND_STRS[ret as usize])
         } else if Self::Nothing as u8 != idx {


### PR DESCRIPTION
#58 

BillMock-HW 0.5 Mini have extra tactile switch nearby DIP switch.
This button is added for displaying CoinCount and Card Count easily

- [x] Add board support for 0.5 mini
- [x] README.md and mdbook update
- [x] Bind to actual logic

Also there was uptime deadlock on EEPROM bodule.
In this ticket resolved it.