### PR TITLE
#40 Generate fingerprint on ELF section, for MPtool

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,14 +10,15 @@ authors = ["Jinwoo Park <pmnxis@gmail.com>"]
 license = "MIT OR Apache-2.0"
 description = "application side of billmock hardware, powered by rust-embedded"
 
+# feature name starting with "hw_" is reserved for mass production config generator
 [features]
 default = ["billmock_default"]
-hw_bug_host_inhibit_floating = []  # #19 bug (https://github.com/pmnxis/billmock-app-rs/issues/19)
+hotfix_hwbug_host_inhibit_floating = []  # #19 bug (https://github.com/pmnxis/billmock-app-rs/issues/19)
 billmock_default = ["hw_mini_0v5"] # To use rust-analzyer utilizing noDefaultFeatures on vscode
 eeprom = []
 svc_button = []                    # SVC button
-hw_0v2 = ["hw_bug_host_inhibit_floating"]
-hw_0v3 = ["hw_bug_host_inhibit_floating"]
+hw_0v2 = ["hotfix_hwbug_host_inhibit_floating"]
+hw_0v3 = ["hotfix_hwbug_host_inhibit_floating"]
 hw_0v4 = ["eeprom"]
 hw_mini_0v4 = ["eeprom"]
 hw_mini_0v5 = ["eeprom", "svc_button"]
@@ -41,7 +42,7 @@ num_enum = { version = "0.7.0", default-features = false } # Application specifi
 bit_field = "0.10"
 nonmax = { version = "0.5.3", default-features = false, features = [] } # to use common NonMax
 static_assertions = "1.1.0"
-env_to_array = { version = "0.3.1", features = ["hex"] }
+env_to_array = { git = "https://github.com/pmnxis/env-to-array.git", branch = "dynamic_array_patch", features = ["hex"] }
 zeroable = "0.2.0"
 const-zero = "0.1.1"
 
@@ -64,6 +65,8 @@ billmock-otp-dev-info = { git = "https://github.com/pmnxis/billmock-mptool.git" 
 [build-dependencies]
 git2 = "0.18" # Git library for Rust
 cargo_metadata = "0.18"
+mp-fingerprint-type = { git = "https://github.com/pmnxis/billmock-mptool.git", rev = "2cab9e6205253445dd9732ef59a048fcad6e63f8" }
+hex = "0.4"
 
 [profile.release]
 # or "z"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ billmock-otp-dev-info = { git = "https://github.com/pmnxis/billmock-mptool.git" 
 [build-dependencies]
 git2 = "0.18" # Git library for Rust
 cargo_metadata = "0.18"
-mp-fingerprint-type = { git = "https://github.com/pmnxis/billmock-mptool.git", branch = "master" }
+mp-fingerprint-type = { git = "https://github.com/pmnxis/billmock-mptool.git" }
 hex = "0.4"
 
 [profile.release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ billmock-otp-dev-info = { git = "https://github.com/pmnxis/billmock-mptool.git" 
 [build-dependencies]
 git2 = "0.18" # Git library for Rust
 cargo_metadata = "0.18"
-mp-fingerprint-type = { git = "https://github.com/pmnxis/billmock-mptool.git", rev = "2cab9e6205253445dd9732ef59a048fcad6e63f8" }
+mp-fingerprint-type = { git = "https://github.com/pmnxis/billmock-mptool.git", branch = "master" }
 hex = "0.4"
 
 [profile.release]

--- a/memory.x
+++ b/memory.x
@@ -7,18 +7,18 @@
 /* STM32G030C8 */
 MEMORY
 {
-  /*
-   * [Mass Production Reminder]
-   * It is feasible to consider switching to the STM32G030C6Tx chip
-   * for the purpose of addressing supply availability and cost reduction.
-   * However, please be aware that the current debug build exceeds the 32KB
-   * limit for the flash section.
-   * As a result, this change would be applicable only when transitioning
-   * to the release build for mass production.
-   *
-   * If you wish to proceed with the change to STM32G030C6Tx,
-   * please modify the FLASH LENGTH to 32KB.
-  */
   FLASH : ORIGIN = 0x08000000, LENGTH = 64K
   RAM : ORIGIN = 0x20000000, LENGTH = 8K
+}
+
+/*
+ * Mass-Production usage ELF section
+ * ref - https://github.com/pmnxis/billmock-app-rs/issues/40
+ * ref - https://sourceware.org/binutils/docs/ld/Output-Section-Type.html
+ */
+SECTIONS {
+  .mp_fingerprint 0 (OVERLAY) :
+  {
+    KEEP(*(.mp_fingerprint))
+  }
 }

--- a/src/components/host_side_bill.rs
+++ b/src/components/host_side_bill.rs
@@ -10,7 +10,7 @@ use embassy_stm32::exti::ExtiInput;
 use embassy_stm32::gpio::{AnyPin, Output};
 
 use crate::semi_layer::buffered_opendrain::{buffered_opendrain_spawn, BufferedOpenDrain};
-#[cfg(not(feature = "hw_bug_host_inhibit_floating"))]
+#[cfg(not(feature = "hotfix_hwbug_host_inhibit_floating"))]
 use crate::semi_layer::buffered_wait::buffered_wait_spawn;
 use crate::semi_layer::buffered_wait::{BufferedWait, InputEventChannel, RawInputPortKind};
 use crate::semi_layer::timing::SharedToggleTiming;
@@ -19,7 +19,7 @@ use crate::types::input_port::InputPortKind;
 use crate::types::player::Player;
 
 pub struct HostSideBill {
-    #[cfg_attr(feature = "hw_bug_host_inhibit_floating", allow(unused))]
+    #[cfg_attr(feature = "hotfix_hwbug_host_inhibit_floating", allow(unused))]
     in_inhibit: BufferedWait,
     pub out_busy: BufferedOpenDrain,
     pub out_vend: BufferedOpenDrain,
@@ -69,7 +69,7 @@ impl HostSideBill {
         unwrap!(spawner.spawn(buffered_opendrain_spawn(&self.out_jam)));
         unwrap!(spawner.spawn(buffered_opendrain_spawn(&self.out_start)));
 
-        #[cfg(not(feature = "hw_bug_host_inhibit_floating"))]
+        #[cfg(not(feature = "hotfix_hwbug_host_inhibit_floating"))]
         unwrap!(spawner.spawn(buffered_wait_spawn(&self.in_inhibit)));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,7 @@
 mod application;
 mod boards;
 mod components;
+mod mp_fingerprint;
 mod semi_layer;
 mod types;
 

--- a/src/mp_fingerprint/mod.rs
+++ b/src/mp_fingerprint/mod.rs
@@ -1,0 +1,23 @@
+/*
+ * SPDX-FileCopyrightText: © 2023 Jinwoo Park (pmnxis@gmail.com)
+ *
+ * SPDX-License-Identifier: MIT OR Apache-2.0
+ */
+
+//! This code is not reflected on program binrary or actual memory.
+//! .mp_fingerprint section is `NOLOAD` and `READONLY` section that
+//! virtually existed in ELF header.
+//! The contents of .mp_fingerprint would be used for billmock-mptool
+//! to determine what kind of board, feature, version, git hash based
+//! from ELF binary.
+
+//! DO NOT USE `&str` or any other slice type
+//! ```rs
+//! #[allow(unused, dead_code)]
+//! #[no_mangle]
+//! #[link_section = ".mp_fingerprint"]
+//! static TEST_FINGER: [u8; 14] = *b"SOME TOML HERE";
+
+use env_to_array::patch_linker_section_from_hex_env;
+
+patch_linker_section_from_hex_env!(".mp_fingerprint", "MP_INFO_TOML", "MP_FINGERPRINT_TOML_HEX");


### PR DESCRIPTION
#40 

### related PR or repo
- https://github.com/pmnxis/billmock-mptool/pull/2
- https://github.com/pmnxis/env-to-array/commit/782c2b265d8a23653321d163ac5cea96c04bc85d

#### `mp-fingerprint-type`
shared types between billmock-mptool and this firmware repo (billmock-app-rs)

#### build.rs
Make toml string

#### Modified env-to-array
Generate dynamic size of toml binary on dummy section by code.

### How works
1. Set dummy section from `memory.x`.
2. `build.rs` generate toml content on initial step of build, by referencing `mp-fingerprint-type`
3. modified env-to-array mapping on dummy section, the name is `.mp_fingerprint`

@perillamint : Thanks for your help in establishing the concept idea.
@SkuldNorniern : Thanks for help in using rust-lld.