### PR TITLE
#45 Enhance business logic and milestone 0.3.0 goal

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -27,7 +27,8 @@ target = "thumbv6m-none-eabi"
 # from the local environment into the actual open-source build.
 [patch.'https://github.com/pmnxis/billmock-app-rs.git']
 card-terminal-adapter = { path = "card-terminal-adapter" }
-billmock-plug-card = { path = "billmock-plug-card" }
+# billmock-plug-card = { path = "billmock-plug-card" }
+billmock-plug-card = { path = "../billmock-plug-ed785" }
 
 # Custom println! To use formatting, use the latest branch.
 # [patch.crates-io]

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -27,8 +27,7 @@ target = "thumbv6m-none-eabi"
 # from the local environment into the actual open-source build.
 [patch.'https://github.com/pmnxis/billmock-app-rs.git']
 card-terminal-adapter = { path = "card-terminal-adapter" }
-# billmock-plug-card = { path = "billmock-plug-card" }
-billmock-plug-card = { path = "../billmock-plug-ed785" }
+billmock-plug-card = { path = "billmock-plug-card" }
 
 # Custom println! To use formatting, use the latest branch.
 # [patch.crates-io]

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -21,9 +21,6 @@ runner = [
 [build]
 target = "thumbv6m-none-eabi"
 
-[env]
-DEFMT_LOG = "trace"
-
 # As described in the `Cargo.toml` located in the root directory of the project,
 # in order to maintain a separation between the NDA code and open-source code,
 # the project follows a re-patching approach for incorporating the library source code

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ out/
 nda
 nda_note.md
 *.svd
+.vscode/launch.json

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 name = "billmock-app-rs"
 edition = "2021"
-version = "0.2.2"
+version = "0.3.0"
 authors = ["Jinwoo Park <pmnxis@gmail.com>"]
 license = "MIT OR Apache-2.0"
 description = "application side of billmock hardware, powered by rust-embedded"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,18 +69,17 @@ mp-fingerprint-type = { git = "https://github.com/pmnxis/billmock-mptool.git" }
 hex = "0.4"
 
 [profile.release]
-# or "z"
 codegen-units = 1
-debug = 2
+debug = 0
 debug-assertions = false # <-
 lto = 'fat'
-opt-level = "s"
+opt-level = "s" # or "z"
 overflow-checks = false # <-
 
 [profile.dev]
-# or "z"
 codegen-units = 1
 debug = 2
 debug-assertions = true # <-
+lto = 'fat'
 opt-level = "s"
 overflow-checks = true # <-

--- a/billmock-plug-card/src/lib.rs
+++ b/billmock-plug-card/src/lib.rs
@@ -44,7 +44,8 @@ impl CardTerminalRxParse for KiccEd785Plug {
     fn post_parse_response_terminal_info(
         &self,
         _raw: &[u8],
-    ) -> Result<(TerminalVersion, RawTerminalId), CardTerminalError> {
+        _prev_terminal_id: &RawTerminalId,
+    ) -> Result<(CardTerminalRxCmd, TerminalVersion, RawTerminalId), CardTerminalError> {
         // implement me for actual usage
         Err(CardTerminalError::UnsupportedSpec)
     }
@@ -83,7 +84,7 @@ impl CardTerminalTxGen for KiccEd785Plug {
     fn push_sale_slot_info<'a>(
         &self,
         buffer: &'a mut [u8],
-        _port_backup: &'a CardReaderPortBackup,
+        _port_backup: &CardReaderPortBackup,
     ) -> &'a [u8] {
         // implement me for actual usage
         &buffer[0..0]
@@ -92,7 +93,7 @@ impl CardTerminalTxGen for KiccEd785Plug {
     fn push_sale_slot_info_partial_inhibit<'a>(
         &self,
         buffer: &'a mut [u8],
-        _port_backup: &'a CardReaderPortBackup,
+        _port_backup: &CardReaderPortBackup,
     ) -> &'a [u8] {
         // implement me for actual usage
         &buffer[0..0]

--- a/build.rs
+++ b/build.rs
@@ -128,5 +128,14 @@ fn main() -> Result<(), Error> {
         fingerprint.to_hex_string(),
     );
 
+    // DEFMT_LOG level configuration
+    let profile = std::env::var("PROFILE").unwrap();
+    let log_level = match profile.as_str() {
+        "release" => "error",
+        _ => "trace",
+    };
+
+    println!("cargo:rustc-env=DEFMT_LOG={}", log_level);
+
     Ok(())
 }

--- a/card-terminal-adapter/src/types.rs
+++ b/card-terminal-adapter/src/types.rs
@@ -86,7 +86,7 @@ pub struct RawPlayersInhibit {
 }
 
 #[repr(C)]
-#[derive(Clone, Zeroable)]
+#[derive(Clone, Zeroable, PartialEq, PartialOrd)]
 pub struct RawTerminalId {
     pub normal: [u8; 10],
     pub extend: [u8; 3],
@@ -192,6 +192,22 @@ impl CardReaderPortBackup {
             }
         }
         0
+    }
+
+    pub fn set_inhibit(&mut self, inhibit: RawPlayersInhibit) {
+        for i in 0..self.raw_card_port_backup.len() {
+            let is_disabled = self.raw_card_port_backup[i].property == SlotProperty::Disabled;
+            let right_side = (i & 1) == 0;
+            let do_inhibit = if !right_side { inhibit.p1 } else { inhibit.p2 };
+
+            if !is_disabled {
+                self.raw_card_port_backup[i].property = if do_inhibit {
+                    SlotProperty::TemporaryDisabled
+                } else {
+                    SlotProperty::Enabled
+                };
+            }
+        }
     }
 }
 

--- a/src/application/mod.rs
+++ b/src/application/mod.rs
@@ -115,6 +115,7 @@ impl Application {
                             .send(CardTerminalTxCmd::ResponseDeviceInfo)
                             .await;
 
+                        // todo! - don't care did_we_ask var, and just backup PortBackup always for inhibit action.
                         if (did_we_ask & 0b111) == 0 {
                             hardware
                                 .card_reader
@@ -184,9 +185,13 @@ impl Application {
                         // read from lock_read for do something
                         // todo! - handle different TId/and something
                     }
-                    CardTerminalRxCmd::ResponseTerminalInfo => {
-                        // read from lock_read for do something
-                        // todo! - handle different TID/and something
+                    // read from lock_read for do something
+                    // handle different TID/and something
+                    CardTerminalRxCmd::ResponseTerminalInfo(TidStatus::Changed) => {
+                        hardware
+                            .card_reader
+                            .send(CardTerminalTxCmd::RequestSaleSlotInfo)
+                            .await;
                     }
 
                     _ => {}

--- a/src/components/eeprom.rs
+++ b/src/components/eeprom.rs
@@ -1339,6 +1339,7 @@ impl Novella {
                         .raw_slot_write_nonblocking(&mut cb, kind, next_slot, new_uptime)
                         .await;
                     after_write(result, sect_idx, &mut cb);
+                    every_2sec = 0;
                 }
             }
 


### PR DESCRIPTION
#45 
There's no overall refactoring on business logic.
Because the logic is currently working well.

But there're following addiction 
- `ResponseTerminalInfo` bind
- `ResponseSaleSlotInfo` bug (from actual ed785 plug)
- better defmt_log level usage per compile